### PR TITLE
feat: add reloadWidgets() to refresh home-screen widgets from JS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
   build-ios:
     runs-on: macos-latest
     env:
-      XCODE_VERSION: 16.2
+      XCODE_VERSION: latest-stable
       TURBO_CACHE_DIR: .turbo/ios
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -170,7 +170,21 @@ struct Provider: TimelineProvider {
 }
 ```
 
-> **Note:** all values are stored as strings — read them with `string(forKey:)` and parse as needed. iOS decides when widget timelines refresh; to force an immediate refresh after writing, call `WidgetCenter.shared.reloadAllTimelines()` from native code (a JS-callable `reloadWidgets()` is on the [roadmap](#-roadmap)).
+> **Note:** all values are stored as strings — read them with `string(forKey:)` and parse as needed.
+
+### 4. Refresh the widget
+
+iOS decides when widget timelines refresh on their own. To make the widget pick up your new values immediately, call `reloadWidgets()` after writing:
+
+```typescript
+import Prefs, { reloadWidgets } from 'react-native-turbo-preferences';
+
+await Prefs.set('streak', '43');
+await reloadWidgets(); // WidgetCenter.shared.reloadAllTimelines()
+await reloadWidgets('StreakWidget'); // …or only one kind: reloadTimelines(ofKind:)
+```
+
+On Android, `reloadWidgets()` broadcasts `ACTION_APPWIDGET_UPDATE` to all of your app's widget providers (the `kind` argument is iOS-only and ignored).
 
 ### Android: sharing with native code
 
@@ -358,6 +372,28 @@ Clears the current store.
 
 ```typescript
 await Prefs.clearAll(); // ⚠️ Use with caution!
+```
+
+### Widget Operations
+
+#### `reloadWidgets(kind?: string): Promise<void>`
+
+Asks the OS to refresh your home-screen widgets so they pick up newly written values.
+
+**Parameters:**
+
+- `kind` (string, optional) - iOS only: refresh a single widget kind (the `kind` you pass to your `WidgetConfiguration`). Omit to refresh all.
+
+**Platform behavior:**
+
+- **iOS:** `WidgetCenter.shared.reloadAllTimelines()`, or `reloadTimelines(ofKind:)` when `kind` is passed
+- **Android:** broadcasts `ACTION_APPWIDGET_UPDATE` to all of the app's widget providers (`kind` ignored)
+
+**Example:**
+
+```typescript
+await Prefs.set('streak', '43');
+await reloadWidgets();
 ```
 
 ## 🪝 React Hooks API
@@ -753,6 +789,7 @@ try {
 | `clearMultiple(keys)` | Delete multiple   | `keys: string[]`              | `Promise<void>`                           |
 | `getAll()`            | Get all keys      | None                          | `Promise<Record<string, string>>`         |
 | `clearAll()`          | Clear store       | None                          | `Promise<void>`                           |
+| `reloadWidgets(kind?)` | Refresh home-screen widgets | `kind?: string` (iOS only) | `Promise<void>`                    |
 
 ### React Hooks API
 
@@ -942,7 +979,7 @@ yarn example       # Run example app
 - [x] ✅ Performance monitoring & benchmarking (iOS + Android)
 - [x] ✅ Memory footprint analysis (iOS + Android)
 - [x] ✅ React hooks (usePreferenceString, usePreferenceNumber, usePreferenceBoolean, usePreferenceObject, usePreferenceNamespace)
-- [ ] 🔜 `reloadWidgets()` — trigger `WidgetCenter.shared.reloadAllTimelines()` from JS after writing
+- [x] ✅ `reloadWidgets()` — trigger `WidgetCenter.shared.reloadAllTimelines()` from JS after writing
 - [x] ✅ Expo config plugin — auto-configure the App Group entitlement from `app.json`
 - [ ] 🔜 Typed values (bool/int/double) so native readers get real types, not strings
 - [ ] 🔜 Change listeners — react to writes from native code / sync hooks across components

--- a/TurboPreferences.podspec
+++ b/TurboPreferences.podspec
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
   s.private_header_files = "ios/**/*.h"
 
   s.swift_version = '5.0'
+  s.weak_frameworks = "WidgetKit"
 
 
   install_modules_dependencies(s)

--- a/android/src/main/java/com/turbopreferences/TurboPreferencesModule.kt
+++ b/android/src/main/java/com/turbopreferences/TurboPreferencesModule.kt
@@ -1,6 +1,8 @@
 package com.turbopreferences
 
+import android.appwidget.AppWidgetManager
 import android.content.Context
+import android.content.Intent
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReadableMap
@@ -177,6 +179,31 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     } catch (e: Exception) {
       android.util.Log.e("TurboPreferences", "Error checking if key contains: ${e.message}")
       promise.reject("E_CONTAINS_FAILED", e.message, e)
+    }
+  }
+
+  override fun reloadWidgets(kind: String?, promise: Promise) {
+    try {
+      // `kind` is a WidgetKit (iOS) concept; on Android all of the app's
+      // widget providers are refreshed.
+      val manager = AppWidgetManager.getInstance(context)
+      val providers = manager.installedProviders
+        .filter { it.provider.packageName == context.packageName }
+
+      for (info in providers) {
+        val ids = manager.getAppWidgetIds(info.provider)
+        if (ids.isEmpty()) continue
+
+        val intent = Intent(AppWidgetManager.ACTION_APPWIDGET_UPDATE).apply {
+          component = info.provider
+          putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
+        }
+        context.sendBroadcast(intent)
+      }
+      promise.resolve(null)
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error reloading widgets: ${e.message}")
+      promise.reject("E_RELOAD_WIDGETS_FAILED", e.message, e)
     }
   }
 

--- a/ios/TurboPreferences.mm
+++ b/ios/TurboPreferences.mm
@@ -246,6 +246,28 @@ RCT_EXPORT_MODULE(TurboPreferences)
     }
 }
 
+- (void)reloadWidgets:(NSString *)kind
+              resolve:(RCTPromiseResolveBlock)resolve
+               reject:(RCTPromiseRejectBlock)reject
+{
+    Class widgetsClass = NSClassFromString(@"TurboPreferencesWidgets");
+    if (!widgetsClass) {
+        reject(@"E_WIDGETS_UNAVAILABLE", @"WidgetKit helper class not found", nil);
+        return;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    if (kind && kind.length > 0) {
+        [widgetsClass performSelector:@selector(reloadTimelinesOfKind:) withObject:kind];
+    } else {
+        [widgetsClass performSelector:@selector(reloadAllTimelines)];
+    }
+#pragma clang diagnostic pop
+
+    resolve(nil);
+}
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params
 {
     return std::make_shared<facebook::react::NativeTurboPreferencesSpecJSI>(params);

--- a/ios/TurboPreferencesWidgets.swift
+++ b/ios/TurboPreferencesWidgets.swift
@@ -1,0 +1,28 @@
+import Foundation
+#if canImport(WidgetKit)
+import WidgetKit
+#endif
+
+/// Obj-C-visible shim around WidgetCenter (a Swift-only API), looked up
+/// from TurboPreferences.mm via NSClassFromString.
+@objc(TurboPreferencesWidgets)
+public class TurboPreferencesWidgets: NSObject {
+
+  @objc(reloadAllTimelines)
+  public static func reloadAllTimelines() {
+    #if canImport(WidgetKit)
+    if #available(iOS 14.0, *) {
+      WidgetCenter.shared.reloadAllTimelines()
+    }
+    #endif
+  }
+
+  @objc(reloadTimelinesOfKind:)
+  public static func reloadTimelines(ofKind kind: String) {
+    #if canImport(WidgetKit)
+    if #available(iOS 14.0, *) {
+      WidgetCenter.shared.reloadTimelines(ofKind: kind)
+    }
+    #endif
+  }
+}

--- a/src/NativeTurboPreferences.ts
+++ b/src/NativeTurboPreferences.ts
@@ -24,6 +24,15 @@ export interface Spec extends TurboModule {
   // ----- Whole-store ops -----
   getAll(): Promise<{ [key: string]: string }>;
   clearAll(): Promise<void>;
+
+  // ----- Widgets -----
+  /**
+   * iOS: WidgetCenter.shared.reloadAllTimelines(), or
+   * reloadTimelines(ofKind:) when a kind is passed.
+   * Android: broadcasts ACTION_APPWIDGET_UPDATE to the app's widget
+   * providers (kind is ignored).
+   */
+  reloadWidgets(kind?: string | null): Promise<void>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('TurboPreferences');

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -12,6 +12,7 @@ jest.mock('../NativeTurboPreferences', () => ({
     getMultiple: jest.fn(),
     clearMultiple: jest.fn(),
     contains: jest.fn(),
+    reloadWidgets: jest.fn(),
   },
 }));
 
@@ -26,6 +27,7 @@ import {
   getMultiple,
   clearMultiple,
   contains,
+  reloadWidgets,
 } from '../index';
 
 // Get the mocked module
@@ -561,6 +563,32 @@ describe('React Native Turbo Preferences', () => {
 
       expect(duration).toBeLessThan(5000); // Should complete in under 5 seconds
       expect(mockModule.setName).toHaveBeenCalledTimes(100);
+    });
+  });
+
+  describe('reloadWidgets', () => {
+    it('should reload all widget timelines when no kind is passed', async () => {
+      mockModule.reloadWidgets.mockResolvedValue(undefined);
+
+      await reloadWidgets();
+
+      expect(mockModule.reloadWidgets).toHaveBeenCalledWith(null);
+    });
+
+    it('should reload a specific widget kind', async () => {
+      mockModule.reloadWidgets.mockResolvedValue(undefined);
+
+      await reloadWidgets('StreakWidget');
+
+      expect(mockModule.reloadWidgets).toHaveBeenCalledWith('StreakWidget');
+    });
+
+    it('should propagate native errors', async () => {
+      mockModule.reloadWidgets.mockRejectedValue(
+        new Error('E_WIDGETS_UNAVAILABLE')
+      );
+
+      await expect(reloadWidgets()).rejects.toThrow('E_WIDGETS_UNAVAILABLE');
     });
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -44,6 +44,10 @@ export function contains(key: string): Promise<boolean> {
   return TurboPreferences.contains(key);
 }
 
+export function reloadWidgets(kind?: string): Promise<void> {
+  return TurboPreferences.reloadWidgets(kind ?? null);
+}
+
 // Export hooks
 export * from './hooks';
 


### PR DESCRIPTION
## Why

After writing to a shared App Group store, iOS decides on its own when widget timelines refresh — new values can take minutes to appear. Every widget tutorial ends with "then call `WidgetCenter.shared.reloadAllTimelines()` from native code". No preference library exposes this from JS; now this one does (roadmap item from #2).

## What

```typescript
await Prefs.set('streak', '43');
await reloadWidgets();                // all widgets
await reloadWidgets('StreakWidget');  // one WidgetKit kind (iOS)
```

### iOS
- `WidgetCenter` is Swift-only, so it's wrapped in an `@objc` Swift shim (`ios/TurboPreferencesWidgets.swift`) resolved at runtime via `NSClassFromString` — no cross-language header dependency, robust across static-lib/framework setups
- `WidgetKit` weak-linked in the podspec
- No `kind` → `reloadAllTimelines()`; with `kind` → `reloadTimelines(ofKind:)`

### Android
- Broadcasts `ACTION_APPWIDGET_UPDATE` to all of the app's widget providers (Glance/AppWidget), so home-screen widgets refresh too
- `kind` is a WidgetKit concept — ignored on Android (documented)

### CI fix (included)
`build-ios` failed on every PR: it pinned Xcode 16.2, but `macos-latest` runner images now only ship Xcode 26.x. Switched `XCODE_VERSION` to `latest-stable`.

## Verification
- 64 JS tests passing (3 new for `reloadWidgets`)
- Ran codegen locally: generated iOS protocol (`reloadWidgets:(NSString * _Nullable)kind resolve:reject:`) and Kotlin abstract method (`reloadWidgets(@Nullable String kind, Promise promise)`) match both native implementations exactly
- Native compilation validated by CI (now actually running with the Xcode fix)
- README: widget guide step 4, API docs section, reference table, roadmap

🤖 Generated with [Claude Code](https://claude.com/claude-code)