### PR TITLE
fix(ci): build iOS on macos-15 with Xcode 16.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,9 +107,12 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
-    runs-on: macos-latest
+    # macos-15: last image with Xcode 16.x — RN 0.79's folly/fmt doesn't
+    # compile under Xcode 26's clang. Move back to macos-latest after
+    # upgrading the example to RN 0.84+.
+    runs-on: macos-15
     env:
-      XCODE_VERSION: latest-stable
+      XCODE_VERSION: '16.4'
       TURBO_CACHE_DIR: .turbo/ios
     steps:
       - name: Checkout


### PR DESCRIPTION
## Why

#4 fixed the stale Xcode 16.2 pin by using `latest-stable`, which surfaced the real problem: **RN 0.79.2 cannot compile under Xcode 26** — its vendored folly/`fmt` hits `consteval … is not a constant expression` errors with the stricter clang. `macos-latest` runners only ship Xcode 26.x now.

## What

Pin `build-ios` to `runs-on: macos-15` (the last image with Xcode 16.x) and `XCODE_VERSION: '16.4'`.

This also gives the iOS native code from #4 (Swift WidgetKit shim + `reloadWidgets`) its first real compile validation, since #4 was merged while build-ios was red.

## Follow-up

Upgrade the example to RN 0.84+ (precompiled binaries by default — folly/fmt no longer built from source), then return CI to `macos-latest`. Tracked as the next milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)