### PR TITLE
feat: add typed values (boolean/int/double) stored as real native types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,12 +107,9 @@ jobs:
           yarn turbo run build:android --cache-dir="${{ env.TURBO_CACHE_DIR }}"
 
   build-ios:
-    # macos-15: last image with Xcode 16.x — RN 0.79's folly/fmt doesn't
-    # compile under Xcode 26's clang. Move back to macos-latest after
-    # upgrading the example to RN 0.84+.
-    runs-on: macos-15
+    runs-on: macos-latest
     env:
-      XCODE_VERSION: '16.4'
+      XCODE_VERSION: latest-stable
       TURBO_CACHE_DIR: .turbo/ios
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -150,27 +150,29 @@ The plugin merges with any existing App Groups, deduplicates, and accepts an arr
 ### 2. Write from React Native
 
 ```typescript
-import Prefs from 'react-native-turbo-preferences';
+import Prefs, { setInt, setBoolean } from 'react-native-turbo-preferences';
 
 await Prefs.setName('group.com.yourcompany.yourapp'); // switch to the App Group container
-await Prefs.set('streak', '42');
-await Prefs.set('lastWorkout', 'Push day');
+await setInt('streak', 42); // stored as a real integer
+await setBoolean('goalReached', true); // stored as a real boolean
+await Prefs.set('lastWorkout', 'Push day'); // strings via set()
 ```
 
 ### 3. Read from your widget (Swift)
+
+Because values are stored as real native types, your widget reads them with the normal typed `UserDefaults` accessors — no string parsing:
 
 ```swift
 struct Provider: TimelineProvider {
   func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
     let defaults = UserDefaults(suiteName: "group.com.yourcompany.yourapp")
-    let streak = defaults?.string(forKey: "streak") ?? "0"
+    let streak = defaults?.integer(forKey: "streak") ?? 0
+    let goalReached = defaults?.bool(forKey: "goalReached") ?? false
     let workout = defaults?.string(forKey: "lastWorkout") ?? "—"
     // build your timeline entry from these values …
   }
 }
 ```
-
-> **Note:** all values are stored as strings — read them with `string(forKey:)` and parse as needed.
 
 ### 4. Refresh the widget
 
@@ -192,7 +194,9 @@ On Android, `setName('my_file')` maps to `getSharedPreferences("my_file", MODE_P
 
 ```kotlin
 val prefs = context.getSharedPreferences("my_file", Context.MODE_PRIVATE)
-val streak = prefs.getString("streak", "0")
+val streak = prefs.getInt("streak", 0)
+val goalReached = prefs.getBoolean("goalReached", false)
+val workout = prefs.getString("lastWorkout", null)
 ```
 
 Data stays inside your app's sandbox. (Unlike libraries that write a world-readable JSON file to external storage, other apps can't read, edit, or delete it — and no storage permissions are required.)
@@ -290,6 +294,40 @@ if (hasTheme) {
   console.log('Theme is configured');
 }
 ```
+
+### Typed Values
+
+Booleans and numbers are stored as **real native types** (not strings), so native readers — widgets, watch apps, SDKs — use their normal typed accessors: `integer(forKey:)` / `bool(forKey:)` on iOS, `getInt` / `getBoolean` on Android.
+
+#### `setBoolean(key: string, value: boolean)` / `getBoolean(key: string)`
+
+```typescript
+await setBoolean('darkMode', true);
+const darkMode = await getBoolean('darkMode'); // true, or null if missing
+```
+
+- iOS: `setBool(_:forKey:)` — Android: `putBoolean`
+
+#### `setInt(key: string, value: number)` / `getInt(key: string)`
+
+```typescript
+await setInt('streak', 42);
+const streak = await getInt('streak'); // 42, or null if missing
+```
+
+- Value must be a 32-bit integer (−2,147,483,648 … 2,147,483,647); `setInt` rejects otherwise
+- iOS: `set(Int, forKey:)` — Android: `putInt`
+
+#### `setDouble(key: string, value: number)` / `getDouble(key: string)`
+
+```typescript
+await setDouble('progress', 0.75);
+const progress = await getDouble('progress'); // 0.75, or null if missing
+```
+
+- iOS: `set(Double, forKey:)` — Android: `putFloat` (SharedPreferences has no `putDouble`, so values round-trip with Float precision on Android)
+
+> Typed getters resolve `null` when the key is missing or holds an incompatible type (e.g. a string). Use `get()`/`set()` for strings, and `usePreferenceObject` / JSON for objects.
 
 ### Batch Operations
 
@@ -784,6 +822,12 @@ try {
 | `set(key, value)`     | Store value       | `key: string, value: string`  | `Promise<void>`                           |
 | `clear(key)`          | Delete key        | `key: string`                 | `Promise<void>`                           |
 | `contains(key)`       | Check existence   | `key: string`                 | `Promise<boolean>`                        |
+| `setBoolean(key, value)` | Store native boolean | `key: string, value: boolean` | `Promise<void>`                     |
+| `getBoolean(key)`     | Retrieve boolean  | `key: string`                 | `Promise<boolean \| null>`                |
+| `setInt(key, value)`  | Store native int32 | `key: string, value: number` | `Promise<void>`                           |
+| `getInt(key)`         | Retrieve integer  | `key: string`                 | `Promise<number \| null>`                 |
+| `setDouble(key, value)` | Store native double/float | `key: string, value: number` | `Promise<void>`                  |
+| `getDouble(key)`      | Retrieve double   | `key: string`                 | `Promise<number \| null>`                 |
 | `setMultiple(values)` | Store multiple    | `values: Array<{key, value}>` | `Promise<void>`                           |
 | `getMultiple(keys)`   | Retrieve multiple | `keys: string[]`              | `Promise<Record<string, string \| null>>` |
 | `clearMultiple(keys)` | Delete multiple   | `keys: string[]`              | `Promise<void>`                           |
@@ -981,7 +1025,7 @@ yarn example       # Run example app
 - [x] ✅ React hooks (usePreferenceString, usePreferenceNumber, usePreferenceBoolean, usePreferenceObject, usePreferenceNamespace)
 - [x] ✅ `reloadWidgets()` — trigger `WidgetCenter.shared.reloadAllTimelines()` from JS after writing
 - [x] ✅ Expo config plugin — auto-configure the App Group entitlement from `app.json`
-- [ ] 🔜 Typed values (bool/int/double) so native readers get real types, not strings
+- [x] ✅ Typed values (bool/int/double) so native readers get real types, not strings
 - [ ] 🔜 Change listeners — react to writes from native code / sync hooks across components
 - [ ] 🔜 Handle-based stores — use multiple namespaces at once without global `setName`
 

--- a/android/src/main/java/com/turbopreferences/TurboPreferencesModule.kt
+++ b/android/src/main/java/com/turbopreferences/TurboPreferencesModule.kt
@@ -57,6 +57,87 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  override fun setBoolean(key: String, value: Boolean, promise: Promise) {
+    try {
+      if (key == "") {
+        promise.reject("E_INVALID_KEY", "Key cannot be empty")
+        return
+      }
+      getPrefs().edit().putBoolean(key, value).apply()
+      promise.resolve(null)
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error setting boolean $key: ${e.message}")
+      promise.reject("E_SET_BOOLEAN_FAILED", e.message, e)
+    }
+  }
+
+  override fun getBoolean(key: String, promise: Promise) {
+    try {
+      val value = getPrefs().all[key]
+      promise.resolve(value as? Boolean)
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error getting boolean $key: ${e.message}")
+      promise.reject("E_GET_BOOLEAN_FAILED", e.message, e)
+    }
+  }
+
+  override fun setInt(key: String, value: Double, promise: Promise) {
+    try {
+      if (key == "") {
+        promise.reject("E_INVALID_KEY", "Key cannot be empty")
+        return
+      }
+      getPrefs().edit().putInt(key, value.toInt()).apply()
+      promise.resolve(null)
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error setting int $key: ${e.message}")
+      promise.reject("E_SET_INT_FAILED", e.message, e)
+    }
+  }
+
+  override fun getInt(key: String, promise: Promise) {
+    try {
+      val value = getPrefs().all[key]
+      if (value is Number) {
+        promise.resolve(value.toInt())
+      } else {
+        promise.resolve(null)
+      }
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error getting int $key: ${e.message}")
+      promise.reject("E_GET_INT_FAILED", e.message, e)
+    }
+  }
+
+  override fun setDouble(key: String, value: Double, promise: Promise) {
+    try {
+      if (key == "") {
+        promise.reject("E_INVALID_KEY", "Key cannot be empty")
+        return
+      }
+      // SharedPreferences has no putDouble — stored as Float
+      getPrefs().edit().putFloat(key, value.toFloat()).apply()
+      promise.resolve(null)
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error setting double $key: ${e.message}")
+      promise.reject("E_SET_DOUBLE_FAILED", e.message, e)
+    }
+  }
+
+  override fun getDouble(key: String, promise: Promise) {
+    try {
+      val value = getPrefs().all[key]
+      if (value is Number) {
+        promise.resolve(value.toDouble())
+      } else {
+        promise.resolve(null)
+      }
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error getting double $key: ${e.message}")
+      promise.reject("E_GET_DOUBLE_FAILED", e.message, e)
+    }
+  }
+
   override fun setMultiple(values: ReadableArray, promise: Promise) {
     try {
       val prefs = getPrefs()

--- a/ios/TurboPreferences.mm
+++ b/ios/TurboPreferences.mm
@@ -117,6 +117,117 @@ RCT_EXPORT_MODULE(TurboPreferences)
     resolve(@(contains));
 }
 
+- (void)setBoolean:(NSString *)key
+             value:(BOOL)value
+           resolve:(RCTPromiseResolveBlock)resolve
+            reject:(RCTPromiseRejectBlock)reject
+{
+    if (!key || key.length == 0) {
+        reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
+        return;
+    }
+
+    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
+    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
+
+    [defaults setBool:value forKey:key];
+    resolve(nil);
+}
+
+- (void)getBoolean:(NSString *)key
+           resolve:(RCTPromiseResolveBlock)resolve
+            reject:(RCTPromiseRejectBlock)reject
+{
+    if (!key || key.length == 0) {
+        reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
+        return;
+    }
+
+    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
+    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
+
+    id value = [defaults objectForKey:key];
+    if ([value isKindOfClass:[NSNumber class]]) {
+        resolve(@([value boolValue]));
+    } else {
+        resolve(nil);
+    }
+}
+
+- (void)setInt:(NSString *)key
+         value:(NSInteger)value
+       resolve:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject
+{
+    if (!key || key.length == 0) {
+        reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
+        return;
+    }
+
+    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
+    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
+
+    [defaults setInteger:value forKey:key];
+    resolve(nil);
+}
+
+- (void)getInt:(NSString *)key
+       resolve:(RCTPromiseResolveBlock)resolve
+        reject:(RCTPromiseRejectBlock)reject
+{
+    if (!key || key.length == 0) {
+        reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
+        return;
+    }
+
+    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
+    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
+
+    id value = [defaults objectForKey:key];
+    if ([value isKindOfClass:[NSNumber class]]) {
+        resolve(@([value longLongValue]));
+    } else {
+        resolve(nil);
+    }
+}
+
+- (void)setDouble:(NSString *)key
+            value:(double)value
+          resolve:(RCTPromiseResolveBlock)resolve
+           reject:(RCTPromiseRejectBlock)reject
+{
+    if (!key || key.length == 0) {
+        reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
+        return;
+    }
+
+    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
+    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
+
+    [defaults setDouble:value forKey:key];
+    resolve(nil);
+}
+
+- (void)getDouble:(NSString *)key
+          resolve:(RCTPromiseResolveBlock)resolve
+           reject:(RCTPromiseRejectBlock)reject
+{
+    if (!key || key.length == 0) {
+        reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
+        return;
+    }
+
+    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
+    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
+
+    id value = [defaults objectForKey:key];
+    if ([value isKindOfClass:[NSNumber class]]) {
+        resolve(@([value doubleValue]));
+    } else {
+        resolve(nil);
+    }
+}
+
 - (void)setMultiple:(NSArray *)values
             resolve:(RCTPromiseResolveBlock)resolve
              reject:(RCTPromiseRejectBlock)reject

--- a/src/NativeTurboPreferences.ts
+++ b/src/NativeTurboPreferences.ts
@@ -1,5 +1,6 @@
 import type { TurboModule } from 'react-native';
 import { TurboModuleRegistry } from 'react-native';
+import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface Spec extends TurboModule {
   // ----- Namespace / file selection -----
@@ -15,6 +16,23 @@ export interface Spec extends TurboModule {
   set(key: string, value: string): Promise<void>;
   clear(key: string): Promise<void>;
   contains(key: string): Promise<boolean>; // aka hasKey
+
+  // ----- Typed ops -----
+  /**
+   * Stored as real native types so native readers (widgets, watch apps,
+   * SDKs) get them without string parsing:
+   * iOS: setBool/setInteger/setDouble on NSUserDefaults.
+   * Android: putBoolean/putInt/putFloat on SharedPreferences
+   * (double is stored as Float — Android has no putDouble).
+   * Typed getters resolve null when the key is missing or holds an
+   * incompatible type.
+   */
+  setBoolean(key: string, value: boolean): Promise<void>;
+  getBoolean(key: string): Promise<boolean | null>;
+  setInt(key: string, value: Int32): Promise<void>;
+  getInt(key: string): Promise<number | null>;
+  setDouble(key: string, value: number): Promise<void>;
+  getDouble(key: string): Promise<number | null>;
 
   // ----- Batch ops -----
   setMultiple(values: { key: string; value: string }[]): Promise<void>;

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -13,6 +13,12 @@ jest.mock('../NativeTurboPreferences', () => ({
     clearMultiple: jest.fn(),
     contains: jest.fn(),
     reloadWidgets: jest.fn(),
+    setBoolean: jest.fn(),
+    getBoolean: jest.fn(),
+    setInt: jest.fn(),
+    getInt: jest.fn(),
+    setDouble: jest.fn(),
+    getDouble: jest.fn(),
   },
 }));
 
@@ -28,6 +34,12 @@ import {
   clearMultiple,
   contains,
   reloadWidgets,
+  setBoolean,
+  getBoolean,
+  setInt,
+  getInt,
+  setDouble,
+  getDouble,
 } from '../index';
 
 // Get the mocked module
@@ -563,6 +575,78 @@ describe('React Native Turbo Preferences', () => {
 
       expect(duration).toBeLessThan(5000); // Should complete in under 5 seconds
       expect(mockModule.setName).toHaveBeenCalledTimes(100);
+    });
+  });
+
+  describe('typed values', () => {
+    it('should set and get a boolean', async () => {
+      mockModule.setBoolean.mockResolvedValue(undefined);
+      mockModule.getBoolean.mockResolvedValue(true);
+
+      await setBoolean('darkMode', true);
+      const value = await getBoolean('darkMode');
+
+      expect(mockModule.setBoolean).toHaveBeenCalledWith('darkMode', true);
+      expect(value).toBe(true);
+    });
+
+    it('should set and get an int', async () => {
+      mockModule.setInt.mockResolvedValue(undefined);
+      mockModule.getInt.mockResolvedValue(42);
+
+      await setInt('streak', 42);
+      const value = await getInt('streak');
+
+      expect(mockModule.setInt).toHaveBeenCalledWith('streak', 42);
+      expect(value).toBe(42);
+    });
+
+    it('should reject setInt with a non-integer', async () => {
+      await expect(setInt('streak', 3.5)).rejects.toThrow(
+        /expects a 32-bit integer/
+      );
+      expect(mockModule.setInt).not.toHaveBeenCalled();
+    });
+
+    it('should reject setInt outside the 32-bit range', async () => {
+      await expect(setInt('streak', 2147483648)).rejects.toThrow(
+        /expects a 32-bit integer/
+      );
+      await expect(setInt('streak', -2147483649)).rejects.toThrow(
+        /expects a 32-bit integer/
+      );
+      expect(mockModule.setInt).not.toHaveBeenCalled();
+    });
+
+    it('should accept setInt at the 32-bit boundaries', async () => {
+      mockModule.setInt.mockResolvedValue(undefined);
+
+      await setInt('max', 2147483647);
+      await setInt('min', -2147483648);
+
+      expect(mockModule.setInt).toHaveBeenCalledWith('max', 2147483647);
+      expect(mockModule.setInt).toHaveBeenCalledWith('min', -2147483648);
+    });
+
+    it('should set and get a double', async () => {
+      mockModule.setDouble.mockResolvedValue(undefined);
+      mockModule.getDouble.mockResolvedValue(3.14);
+
+      await setDouble('ratio', 3.14);
+      const value = await getDouble('ratio');
+
+      expect(mockModule.setDouble).toHaveBeenCalledWith('ratio', 3.14);
+      expect(value).toBe(3.14);
+    });
+
+    it('should resolve null for missing typed keys', async () => {
+      mockModule.getBoolean.mockResolvedValue(null);
+      mockModule.getInt.mockResolvedValue(null);
+      mockModule.getDouble.mockResolvedValue(null);
+
+      expect(await getBoolean('missing')).toBeNull();
+      expect(await getInt('missing')).toBeNull();
+      expect(await getDouble('missing')).toBeNull();
     });
   });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,6 +48,37 @@ export function reloadWidgets(kind?: string): Promise<void> {
   return TurboPreferences.reloadWidgets(kind ?? null);
 }
 
+export function setBoolean(key: string, value: boolean): Promise<void> {
+  return TurboPreferences.setBoolean(key, value);
+}
+
+export function getBoolean(key: string): Promise<boolean | null> {
+  return TurboPreferences.getBoolean(key);
+}
+
+export function setInt(key: string, value: number): Promise<void> {
+  if (!Number.isInteger(value) || value < -2147483648 || value > 2147483647) {
+    return Promise.reject(
+      new TypeError(
+        `setInt expects a 32-bit integer, got ${value}. Use setDouble for other numbers.`
+      )
+    );
+  }
+  return TurboPreferences.setInt(key, value);
+}
+
+export function getInt(key: string): Promise<number | null> {
+  return TurboPreferences.getInt(key);
+}
+
+export function setDouble(key: string, value: number): Promise<void> {
+  return TurboPreferences.setDouble(key, value);
+}
+
+export function getDouble(key: string): Promise<number | null> {
+  return TurboPreferences.getDouble(key);
+}
+
 // Export hooks
 export * from './hooks';
 


### PR DESCRIPTION
## Why

The core widget/App-Group use case has native code on the reading end. With string-only storage, a Swift widget had to parse `"42"` and `"true"` out of strings. Roadmap item from #2.

## What

```typescript
await setInt('streak', 42);
await setBoolean('goalReached', true);
await setDouble('progress', 0.75);
```

…and the widget reads them with normal typed accessors:

```swift
let streak = defaults?.integer(forKey: "streak") ?? 0
let goalReached = defaults?.bool(forKey: "goalReached") ?? false
```

### Semantics
- **iOS:** `setBool` / `setInteger` / `setDouble` on NSUserDefaults
- **Android:** `putBoolean` / `putInt` / `putFloat` (no `putDouble` in SharedPreferences — doubles round-trip with Float precision on Android; documented)
- Typed getters resolve `null` when the key is missing or holds an incompatible type
- `setInt` validates 32-bit range in the JS wrapper (matches Android `putInt`; spec uses codegen `Int32`)

### Also
- CI: reverts `build-ios` to `macos-latest` + `latest-stable` — the macos-15/Xcode 16.4 pin rode into main via #6 (the upgrade branch was cut from the #5 branch), so this PR is the first to build under current Xcode with RN 0.86
- README: Typed Values API section, reference table, widget guide now typed end-to-end, roadmap

## Verification
- 71 tests passing (7 new), typecheck + lint clean
- Codegen-generated signatures matched on both platforms (`NSInteger`/`double` mappings)
- Native compile validated by CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)