### PR TITLE
feat!: handle-based stores — createStore() replaces global setName

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It's also a great fit whenever native code (SDKs, Settings.bundle, Android home-
 - 🪝 **React Hooks** — Convenient hooks for reactive state management
 - 📱 **Cross-Platform** — Same JS API for iOS + Android with native optimizations
 - 📦 **Lightweight** — Wraps native APIs (NSUserDefaults, SharedPreferences) directly, no custom storage format
-- 🗂 **Namespace Support** — Switch between the default store and any named suite/file
+- 🗂 **Multiple Stores** — Hold handles to the default store, named files, and App Groups side by side
 - 🛠 **Batch Operations** — Set/get/remove multiple keys at once for efficiency
 - 🧹 **Full Control** — Get all keys, clear store, check existence
 - 🔒 **Type Safe** — Written in TypeScript with full type definitions
@@ -83,16 +83,19 @@ Works with development builds and EAS. To share data with widgets/extensions, ad
 ### Imperative API
 
 ```typescript
-import Prefs from 'react-native-turbo-preferences';
+import Prefs, { createStore } from 'react-native-turbo-preferences';
 
-// Basic usage
+// Basic usage (default store)
 await Prefs.set('username', 'Hamza');
 const username = await Prefs.get('username');
 console.log(username); // "Hamza"
 
-// Use a named store
-await Prefs.setName('MyPrefs');
-await Prefs.set('theme', 'dark');
+// Named stores are handles — use as many as you need, at the same time
+const settings = createStore('settings');
+const appGroup = createStore('group.com.yourcompany.yourapp');
+
+await settings.set('theme', 'dark');
+await appGroup.setInt('streak', 42); // visible to your widget
 ```
 
 ### React Hooks API
@@ -150,13 +153,16 @@ The plugin merges with any existing App Groups, deduplicates, and accepts an arr
 ### 2. Write from React Native
 
 ```typescript
-import Prefs, { setInt, setBoolean } from 'react-native-turbo-preferences';
+import { createStore } from 'react-native-turbo-preferences';
 
-await Prefs.setName('group.com.yourcompany.yourapp'); // switch to the App Group container
-await setInt('streak', 42); // stored as a real integer
-await setBoolean('goalReached', true); // stored as a real boolean
-await Prefs.set('lastWorkout', 'Push day'); // strings via set()
+const appGroup = createStore('group.com.yourcompany.yourapp');
+
+await appGroup.setInt('streak', 42); // stored as a real integer
+await appGroup.setBoolean('goalReached', true); // stored as a real boolean
+await appGroup.set('lastWorkout', 'Push day'); // strings via set()
 ```
+
+The handle only touches the App Group container — the rest of your app keeps using the default store (or other handles) at the same time.
 
 ### 3. Read from your widget (Swift)
 
@@ -203,23 +209,43 @@ Data stays inside your app's sandbox. (Unlike libraries that write a world-reada
 
 ## 📖 API Documentation
 
-### Basic Methods
+### Stores
 
-#### `setName(name?: string | null): Promise<void>`
+#### `createStore(name?: string): PreferenceStore`
 
-Switches the storage namespace.
+Creates a handle to a preference store. Handles are cheap JS objects — create as many as you need and use several stores **at the same time**, with no global state.
 
 **Parameters:**
 
-- `name` (string, optional) - Namespace name. Pass null/undefined to reset to default store.
+- `name` (string, optional) - iOS: `UserDefaults` suite (e.g. an App Group). Android: `SharedPreferences` file name. Omit for the default store.
 
-**Returns:** `Promise<void>`
+**Returns:** a `PreferenceStore` with the full API scoped to that store: `get`/`set`/`clear`/`contains`, typed values, batch ops, `getAll`/`clearAll`, and `addListener` (fires only for that store's changes).
 
 **Example:**
 
 ```typescript
-// iOS: uses UserDefaults(suiteName:)
-// Android: uses getSharedPreferences(name, MODE_PRIVATE)
+const settings = createStore('settings');
+const appGroup = createStore('group.com.yourcompany.yourapp');
+
+await settings.set('theme', 'dark');
+await appGroup.setInt('streak', 42);
+
+const sub = appGroup.addListener((event) => {
+  console.log('widget data changed:', event.key);
+});
+```
+
+### Basic Methods
+
+The top-level functions below operate on the **default store** (or the store selected with the deprecated `setName`).
+
+#### `setName(name?: string | null): Promise<void>` (deprecated)
+
+Switches the store the top-level functions point at. **Prefer `createStore()`** — `setName` is a global switch shared by every call in your app, which invites subtle bugs when two features use different namespaces.
+
+> Migration note: the selection now lives in JS and resets on app restart — this was always Android's behavior; iOS used to persist it across launches.
+
+```typescript
 await Prefs.setName('group.com.your.app');
 ```
 
@@ -811,17 +837,30 @@ class AppConfig {
 
 ## 🔧 Configuration
 
-### Namespace Management
+### Working with Multiple Stores
 
 ```typescript
-// Use default store
-await Prefs.setName('');
+import { createStore } from 'react-native-turbo-preferences';
 
-// Use app group (iOS) or named file (Android)
-await Prefs.setName('group.com.your.app');
+const defaults = createStore(); // default store
+const appGroup = createStore('group.com.your.app'); // iOS App Group
+const settings = createStore('UserSettings'); // named file
 
-// Use custom namespace
-await Prefs.setName('UserSettings');
+// All usable at the same time — no global switching
+await defaults.set('lastScreen', 'home');
+await appGroup.setInt('streak', 42);
+await settings.setBoolean('darkMode', true);
+```
+
+Hooks accept a store handle as their second argument:
+
+```typescript
+const appGroup = createStore('group.com.your.app');
+
+function StreakBadge() {
+  const [streak] = usePreferenceNumber('streak', appGroup);
+  return <Text>{streak ?? 0}</Text>;
+}
 ```
 
 ### Error Handling
@@ -841,7 +880,8 @@ try {
 
 | Method                | Description       | Parameters                    | Returns                                   |
 | --------------------- | ----------------- | ----------------------------- | ----------------------------------------- |
-| `setName(name)`       | Switch namespace  | `name: string \| null`        | `Promise<void>`                           |
+| `createStore(name?)`  | Create a store handle | `name?: string`           | `PreferenceStore`                         |
+| `setName(name)` ⚠️ deprecated | Switch global namespace | `name: string \| null` | `Promise<void>`                     |
 | `get(key)`            | Retrieve value    | `key: string`                 | `Promise<string \| null>`                 |
 | `set(key, value)`     | Store value       | `key: string, value: string`  | `Promise<void>`                           |
 | `clear(key)`          | Delete key        | `key: string`                 | `Promise<void>`                           |
@@ -1052,7 +1092,7 @@ yarn example       # Run example app
 - [x] ✅ Expo config plugin — auto-configure the App Group entitlement from `app.json`
 - [x] ✅ Typed values (bool/int/double) so native readers get real types, not strings
 - [x] ✅ Change listeners — react to writes from native code / sync hooks across components
-- [ ] 🔜 Handle-based stores — use multiple namespaces at once without global `setName`
+- [x] ✅ Handle-based stores — use multiple namespaces at once without global `setName`
 
 ## 🤝 Contributing
 

--- a/android/src/main/java/com/turbopreferences/TurboPreferencesModule.kt
+++ b/android/src/main/java/com/turbopreferences/TurboPreferencesModule.kt
@@ -12,7 +12,6 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.module.annotations.ReactModule
 import android.content.SharedPreferences
 
-
 @ReactModule(name = TurboPreferencesModule.NAME)
 class TurboPreferencesModule(reactContext: ReactApplicationContext) :
   NativeTurboPreferencesSpec(reactContext) {
@@ -24,63 +23,72 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     return NAME
   }
 
-  private var prefs_name = "default"
+  private val DEFAULT_FILE = "default"
 
-  // The system holds listeners weakly — keep a strong reference here
-  private val changeListener =
-    SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
-      val event = Arguments.createMap()
-      if (key != null) {
-        event.putString("key", key)
-      } else {
-        // key is null when the store was cleared as a whole (API 30+)
-        event.putNull("key")
+  // One change listener per touched store, held strongly — the system
+  // only keeps weak references to SharedPreferences listeners
+  private val watchedStores =
+    mutableMapOf<String, Pair<SharedPreferences, SharedPreferences.OnSharedPreferenceChangeListener>>()
+
+  private fun fileFor(name: String?): String {
+    return if (name.isNullOrEmpty()) DEFAULT_FILE else name
+  }
+
+  private fun getPrefs(name: String?): SharedPreferences {
+    val file = fileFor(name)
+    val prefs = context.getSharedPreferences(file, Context.MODE_PRIVATE)
+    watchStore(file, prefs)
+    return prefs
+  }
+
+  @Synchronized
+  private fun watchStore(file: String, prefs: SharedPreferences) {
+    if (watchedStores.containsKey(file)) return
+    val listener =
+      SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
+        val event = Arguments.createMap()
+        if (key != null) {
+          event.putString("key", key)
+        } else {
+          // key is null when the store was cleared as a whole (API 30+)
+          event.putNull("key")
+        }
+        if (file == DEFAULT_FILE) {
+          event.putNull("store")
+        } else {
+          event.putString("store", file)
+        }
+        emitOnPreferenceChange(event)
       }
-      emitOnPreferenceChange(event)
-    }
-  private var listenedPrefs: SharedPreferences? = null
-
-  private fun getPrefs(): SharedPreferences {
-    return context.getSharedPreferences(prefs_name, Context.MODE_PRIVATE)
+    prefs.registerOnSharedPreferenceChangeListener(listener)
+    watchedStores[file] = Pair(prefs, listener)
   }
 
-  private fun attachChangeListener() {
-    val prefs = getPrefs()
-    if (prefs === listenedPrefs) return
-    listenedPrefs?.unregisterOnSharedPreferenceChangeListener(changeListener)
-    prefs.registerOnSharedPreferenceChangeListener(changeListener)
-    listenedPrefs = prefs
-  }
-
-  override fun initialize() {
-    super.initialize()
-    attachChangeListener()
-  }
-
+  @Synchronized
   override fun invalidate() {
-    listenedPrefs?.unregisterOnSharedPreferenceChangeListener(changeListener)
-    listenedPrefs = null
+    for ((prefs, listener) in watchedStores.values) {
+      prefs.unregisterOnSharedPreferenceChangeListener(listener)
+    }
+    watchedStores.clear()
     super.invalidate()
   }
 
-  override fun setName(name: String?, promise: Promise) {
+  // ----- Single key ops -----
+
+  override fun get(name: String?, key: String, promise: Promise) {
     try {
-      prefs_name = if (name.isNullOrEmpty()) "default" else name
-      attachChangeListener()
-      promise.resolve(null)
+      val value = getPrefs(name).getString(key, null)
+      promise.resolve(value)
     } catch (e: Exception) {
-      android.util.Log.e("TurboPreferences", "Error setting name: ${e.message}")
-      promise.reject("E_SET_NAME_FAILED", e.message, e)
+      android.util.Log.e("TurboPreferences", "Error getting key $key: ${e.message}")
+      promise.reject("E_GET_FAILED", e.message, e)
     }
   }
 
-  override fun set(key: String, value: String, promise: Promise) {
+  override fun set(name: String?, key: String, value: String, promise: Promise) {
     try {
       if (key != "") {
-        val prefs = getPrefs()
-        val editor = prefs.edit()
-        editor.putString(key, value)
-        editor.apply()
+        getPrefs(name).edit().putString(key, value).apply()
         promise.resolve(null)
       } else {
         promise.reject("E_INVALID_KEY", "Key cannot be empty")
@@ -91,13 +99,34 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun setBoolean(key: String, value: Boolean, promise: Promise) {
+  override fun clear(name: String?, key: String, promise: Promise) {
+    try {
+      getPrefs(name).edit().remove(key).apply()
+      promise.resolve(null)
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error clearing key $key: ${e.message}")
+      promise.reject("E_CLEAR_FAILED", e.message, e)
+    }
+  }
+
+  override fun contains(name: String?, key: String, promise: Promise) {
+    try {
+      promise.resolve(getPrefs(name).contains(key))
+    } catch (e: Exception) {
+      android.util.Log.e("TurboPreferences", "Error checking if key contains: ${e.message}")
+      promise.reject("E_CONTAINS_FAILED", e.message, e)
+    }
+  }
+
+  // ----- Typed ops -----
+
+  override fun setBoolean(name: String?, key: String, value: Boolean, promise: Promise) {
     try {
       if (key == "") {
         promise.reject("E_INVALID_KEY", "Key cannot be empty")
         return
       }
-      getPrefs().edit().putBoolean(key, value).apply()
+      getPrefs(name).edit().putBoolean(key, value).apply()
       promise.resolve(null)
     } catch (e: Exception) {
       android.util.Log.e("TurboPreferences", "Error setting boolean $key: ${e.message}")
@@ -105,9 +134,9 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun getBoolean(key: String, promise: Promise) {
+  override fun getBoolean(name: String?, key: String, promise: Promise) {
     try {
-      val value = getPrefs().all[key]
+      val value = getPrefs(name).all[key]
       promise.resolve(value as? Boolean)
     } catch (e: Exception) {
       android.util.Log.e("TurboPreferences", "Error getting boolean $key: ${e.message}")
@@ -115,13 +144,13 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun setInt(key: String, value: Double, promise: Promise) {
+  override fun setInt(name: String?, key: String, value: Double, promise: Promise) {
     try {
       if (key == "") {
         promise.reject("E_INVALID_KEY", "Key cannot be empty")
         return
       }
-      getPrefs().edit().putInt(key, value.toInt()).apply()
+      getPrefs(name).edit().putInt(key, value.toInt()).apply()
       promise.resolve(null)
     } catch (e: Exception) {
       android.util.Log.e("TurboPreferences", "Error setting int $key: ${e.message}")
@@ -129,9 +158,9 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun getInt(key: String, promise: Promise) {
+  override fun getInt(name: String?, key: String, promise: Promise) {
     try {
-      val value = getPrefs().all[key]
+      val value = getPrefs(name).all[key]
       if (value is Number) {
         promise.resolve(value.toInt())
       } else {
@@ -143,14 +172,14 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun setDouble(key: String, value: Double, promise: Promise) {
+  override fun setDouble(name: String?, key: String, value: Double, promise: Promise) {
     try {
       if (key == "") {
         promise.reject("E_INVALID_KEY", "Key cannot be empty")
         return
       }
       // SharedPreferences has no putDouble — stored as Float
-      getPrefs().edit().putFloat(key, value.toFloat()).apply()
+      getPrefs(name).edit().putFloat(key, value.toFloat()).apply()
       promise.resolve(null)
     } catch (e: Exception) {
       android.util.Log.e("TurboPreferences", "Error setting double $key: ${e.message}")
@@ -158,9 +187,9 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun getDouble(key: String, promise: Promise) {
+  override fun getDouble(name: String?, key: String, promise: Promise) {
     try {
-      val value = getPrefs().all[key]
+      val value = getPrefs(name).all[key]
       if (value is Number) {
         promise.resolve(value.toDouble())
       } else {
@@ -172,10 +201,11 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun setMultiple(values: ReadableArray, promise: Promise) {
+  // ----- Batch ops -----
+
+  override fun setMultiple(name: String?, values: ReadableArray, promise: Promise) {
     try {
-      val prefs = getPrefs()
-      val editor = prefs.edit()
+      val editor = getPrefs(name).edit()
 
       for (i in 0 until values.size()) {
         val item = values.getMap(i)
@@ -183,7 +213,7 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
           val key = item.getString("key") ?: ""
           val value = item.getString("value") ?: ""
 
-          if(key != ""){
+          if (key != "") {
             editor.putString(key, value)
           }
         }
@@ -196,11 +226,11 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun getMultiple(keys: ReadableArray, promise: Promise) {
+  override fun getMultiple(name: String?, keys: ReadableArray, promise: Promise) {
     try {
-      val prefs = getPrefs()
+      val prefs = getPrefs(name)
       val result: WritableMap = Arguments.createMap()
-      
+
       for (i in 0 until keys.size()) {
         val key = keys.getString(i)
         if (key != null) {
@@ -208,7 +238,7 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
           result.putString(key, value)
         }
       }
-      
+
       promise.resolve(result)
     } catch (e: Exception) {
       android.util.Log.e("TurboPreferences", "Error getting multiple keys: ${e.message}")
@@ -216,11 +246,10 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun clearMultiple(keys: ReadableArray, promise: Promise) {
+  override fun clearMultiple(name: String?, keys: ReadableArray, promise: Promise) {
     try {
-      val prefs = getPrefs()
-      val editor = prefs.edit()
-      
+      val editor = getPrefs(name).edit()
+
       for (i in 0 until keys.size()) {
         val key = keys.getString(i)
         if (key != null) {
@@ -235,27 +264,17 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun get(key: String, promise: Promise) {
-    try {
-      val prefs = getPrefs()
-      val value = prefs.getString(key, null) 
-      promise.resolve(value)
-    } catch (e: Exception) {
-      android.util.Log.e("TurboPreferences", "Error getting key $key: ${e.message}")
-      promise.reject("E_GET_FAILED", e.message, e)
-    }
-  }
+  // ----- Whole-store ops -----
 
-  override fun getAll(promise: Promise) {
-     try {
-      val prefs = getPrefs()
-      val allPrefs = prefs.all
-      
+  override fun getAll(name: String?, promise: Promise) {
+    try {
+      val allPrefs = getPrefs(name).all
+
       val writableMap: WritableMap = Arguments.createMap()
       for ((key, value) in allPrefs) {
         writableMap.putString(key.toString(), value.toString())
       }
-      
+
       promise.resolve(writableMap)
     } catch (e: Exception) {
       android.util.Log.e("TurboPreferences", "Error getting all preferences: ${e.message}")
@@ -263,21 +282,9 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun clear(key: String, promise: Promise) {
-     try {
-      val prefs = getPrefs()
-      prefs.edit().remove(key).apply()
-      promise.resolve(null)
-    } catch (e: Exception) {
-      android.util.Log.e("TurboPreferences", "Error clearing key $key: ${e.message}")
-      promise.reject("E_CLEAR_FAILED", e.message, e)
-    }
-  }
-
-  override fun clearAll(promise: Promise) {
-     try {
-      val prefs = getPrefs()
-      prefs.edit().clear().apply()
+  override fun clearAll(name: String?, promise: Promise) {
+    try {
+      getPrefs(name).edit().clear().apply()
       promise.resolve(null)
     } catch (e: Exception) {
       android.util.Log.e("TurboPreferences", "Error clearing all preferences: ${e.message}")
@@ -285,17 +292,7 @@ class TurboPreferencesModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  override fun contains(key: String, promise: Promise) {
-    try {
-      val prefs = getPrefs()
-      val containsKey = prefs.contains(key)
-      
-      promise.resolve(containsKey)
-    } catch (e: Exception) {
-      android.util.Log.e("TurboPreferences", "Error checking if key contains: ${e.message}")
-      promise.reject("E_CONTAINS_FAILED", e.message, e)
-    }
-  }
+  // ----- Widgets -----
 
   override fun reloadWidgets(kind: String?, promise: Promise) {
     try {

--- a/ios/TurboPreferences.mm
+++ b/ios/TurboPreferences.mm
@@ -2,18 +2,71 @@
 #import <React/RCTLog.h>
 
 @implementation TurboPreferences {
-  NSDictionary *_snapshot;
+  NSMutableDictionary<NSString *, NSUserDefaults *> *_defaultsCache;
+  // Per-store snapshots for change detection, keyed by store token
+  // (@"" for the default store)
+  NSMutableDictionary<NSString *, NSDictionary *> *_snapshots;
   BOOL _observing;
-  BOOL _suppressChangeEvents;
 }
 
 RCT_EXPORT_MODULE(TurboPreferences)
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _defaultsCache = [NSMutableDictionary dictionary];
+        _snapshots = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
 
 - (void)dealloc
 {
     if (_observing) {
         [[NSNotificationCenter defaultCenter] removeObserver:self];
     }
+}
+
+#pragma mark - Store access
+
+- (NSString *)tokenForName:(NSString *)name
+{
+    return (name && name.length > 0) ? name : @"";
+}
+
+- (NSString *)domainForToken:(NSString *)token
+{
+    return token.length > 0 ? token : [[NSBundle mainBundle] bundleIdentifier];
+}
+
+- (NSUserDefaults *)defaultsForName:(NSString *)name
+{
+    NSString *token = [self tokenForName:name];
+
+    @synchronized (self) {
+        NSUserDefaults *defaults = _defaultsCache[token];
+        if (!defaults) {
+            defaults = token.length > 0
+                ? [[NSUserDefaults alloc] initWithSuiteName:token]
+                : [NSUserDefaults standardUserDefaults];
+            _defaultsCache[token] = defaults;
+            // Start change-watching this store from its current state
+            if (_observing && !_snapshots[token]) {
+                _snapshots[token] = [self snapshotForToken:token] ?: @{};
+            }
+        }
+        return defaults;
+    }
+}
+
+#pragma mark - Change events
+
+- (NSDictionary *)snapshotForToken:(NSString *)token
+{
+    NSUserDefaults *defaults = _defaultsCache[token]
+        ?: (token.length > 0 ? [[NSUserDefaults alloc] initWithSuiteName:token]
+                             : [NSUserDefaults standardUserDefaults]);
+    return [defaults persistentDomainForName:[self domainForToken:token]] ?: @{};
 }
 
 // The generated emit helpers call into a std::function that is only wired up
@@ -23,7 +76,11 @@ RCT_EXPORT_MODULE(TurboPreferences)
     [super setEventEmitterCallback:eventEmitterCallbackWrapper];
     if (!_observing) {
         _observing = YES;
-        _snapshot = [self currentDomainSnapshot];
+        @synchronized (self) {
+            for (NSString *token in _defaultsCache) {
+                _snapshots[token] = [self snapshotForToken:token] ?: @{};
+            }
+        }
         [[NSNotificationCenter defaultCenter] addObserver:self
                                                  selector:@selector(userDefaultsDidChange:)
                                                      name:NSUserDefaultsDidChangeNotification
@@ -31,84 +88,34 @@ RCT_EXPORT_MODULE(TurboPreferences)
     }
 }
 
-// Snapshot of the current store's persistent domain — unlike
-// dictionaryRepresentation, this excludes NSGlobalDomain noise.
-- (NSDictionary *)currentDomainSnapshot
-{
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    NSString *domain = (suiteName && suiteName.length > 0)
-        ? suiteName
-        : [[NSBundle mainBundle] bundleIdentifier];
-    return [defaults persistentDomainForName:domain] ?: @{};
-}
-
 - (void)userDefaultsDidChange:(NSNotification *)notification
 {
     @synchronized (self) {
-        NSDictionary *newSnapshot = [self currentDomainSnapshot];
-        NSDictionary *oldSnapshot = _snapshot ?: @{};
-        _snapshot = newSnapshot;
+        for (NSString *token in _snapshots.allKeys) {
+            NSDictionary *oldSnapshot = _snapshots[token] ?: @{};
+            NSDictionary *newSnapshot = [self snapshotForToken:token];
+            _snapshots[token] = newSnapshot;
 
-        if (_suppressChangeEvents) {
-            return;
-        }
+            NSMutableSet *keys = [NSMutableSet setWithArray:oldSnapshot.allKeys];
+            [keys addObjectsFromArray:newSnapshot.allKeys];
 
-        NSMutableSet *keys = [NSMutableSet setWithArray:oldSnapshot.allKeys];
-        [keys addObjectsFromArray:newSnapshot.allKeys];
-
-        for (NSString *key in keys) {
-            if ([key hasPrefix:@"__turbo_preferences_"]) {
-                continue;
+            id storeValue = token.length > 0 ? token : [NSNull null];
+            for (NSString *key in keys) {
+                id oldValue = oldSnapshot[key];
+                id newValue = newSnapshot[key];
+                if (oldValue == newValue || [oldValue isEqual:newValue]) {
+                    continue;
+                }
+                [self emitOnPreferenceChange:@{ @"key": key, @"store": storeValue }];
             }
-            id oldValue = oldSnapshot[key];
-            id newValue = newSnapshot[key];
-            if (oldValue == newValue || [oldValue isEqual:newValue]) {
-                continue;
-            }
-            [self emitOnPreferenceChange:@{ @"key": key }];
         }
     }
 }
 
-- (NSUserDefaults *)userDefaults {
-    static NSUserDefaults *defaults = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        defaults = [NSUserDefaults standardUserDefaults];
-    });
-    return defaults;
-}
+#pragma mark - Single key ops
 
-- (NSUserDefaults *)userDefaultsWithSuite:(NSString *)suiteName {
-    if (suiteName && suiteName.length > 0) {
-        return [[NSUserDefaults alloc] initWithSuiteName:suiteName];
-    }
-    return [self userDefaults];
-}
-
-- (void)setName:(NSString *)name
-        resolve:(RCTPromiseResolveBlock)resolve
-         reject:(RCTPromiseRejectBlock)reject
-{
-    // This method is mainly for Android compatibility
-    // On iOS, we'll store the suite name in a special key for reference
-    @synchronized (self) {
-        // Switching stores is not a value change — swap the snapshot silently
-        _suppressChangeEvents = YES;
-        if (name && name.length > 0) {
-            [[self userDefaults] setObject:name forKey:@"__turbo_preferences_suite_name__"];
-        } else {
-            [[self userDefaults] removeObjectForKey:@"__turbo_preferences_suite_name__"];
-        }
-        [[self userDefaults] synchronize];
-        _snapshot = [self currentDomainSnapshot];
-        _suppressChangeEvents = NO;
-    }
-    resolve(@(YES));
-}
-
-- (void)get:(NSString *)key
+- (void)get:(NSString *)name
+        key:(NSString *)key
     resolve:(RCTPromiseResolveBlock)resolve
      reject:(RCTPromiseRejectBlock)reject
 {
@@ -116,15 +123,13 @@ RCT_EXPORT_MODULE(TurboPreferences)
         reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
         return;
     }
-    
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
-    NSString *value = [defaults stringForKey:key];
+
+    NSString *value = [[self defaultsForName:name] stringForKey:key];
     resolve(value);
 }
 
-- (void)set:(NSString *)key
+- (void)set:(NSString *)name
+        key:(NSString *)key
       value:(NSString *)value
     resolve:(RCTPromiseResolveBlock)resolve
      reject:(RCTPromiseRejectBlock)reject
@@ -133,25 +138,18 @@ RCT_EXPORT_MODULE(TurboPreferences)
         reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
         return;
     }
-    
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
+
+    NSUserDefaults *defaults = [self defaultsForName:name];
     if (value) {
         [defaults setObject:value forKey:key];
     } else {
         [defaults removeObjectForKey:key];
     }
-    
-    BOOL success = [defaults synchronize];
-    if (success) {
-        resolve(@(YES));
-    } else {
-        reject(@"SYNC_FAILED", @"Failed to synchronize UserDefaults", nil);
-    }
+    resolve(nil);
 }
 
-- (void)clear:(NSString *)key
+- (void)clear:(NSString *)name
+          key:(NSString *)key
       resolve:(RCTPromiseResolveBlock)resolve
        reject:(RCTPromiseRejectBlock)reject
 {
@@ -159,21 +157,13 @@ RCT_EXPORT_MODULE(TurboPreferences)
         reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
         return;
     }
-    
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
-    [defaults removeObjectForKey:key];
-    BOOL success = [defaults synchronize];
-    
-    if (success) {
-        resolve(@(YES));
-    } else {
-        reject(@"SYNC_FAILED", @"Failed to synchronize UserDefaults", nil);
-    }
+
+    [[self defaultsForName:name] removeObjectForKey:key];
+    resolve(nil);
 }
 
-- (void)contains:(NSString *)key
+- (void)contains:(NSString *)name
+             key:(NSString *)key
          resolve:(RCTPromiseResolveBlock)resolve
           reject:(RCTPromiseRejectBlock)reject
 {
@@ -181,15 +171,15 @@ RCT_EXPORT_MODULE(TurboPreferences)
         reject(@"INVALID_KEY", @"Key cannot be null or empty", nil);
         return;
     }
-    
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
-    BOOL contains = [defaults objectForKey:key] != nil;
+
+    BOOL contains = [[self defaultsForName:name] objectForKey:key] != nil;
     resolve(@(contains));
 }
 
-- (void)setBoolean:(NSString *)key
+#pragma mark - Typed ops
+
+- (void)setBoolean:(NSString *)name
+               key:(NSString *)key
              value:(BOOL)value
            resolve:(RCTPromiseResolveBlock)resolve
             reject:(RCTPromiseRejectBlock)reject
@@ -199,14 +189,12 @@ RCT_EXPORT_MODULE(TurboPreferences)
         return;
     }
 
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-
-    [defaults setBool:value forKey:key];
+    [[self defaultsForName:name] setBool:value forKey:key];
     resolve(nil);
 }
 
-- (void)getBoolean:(NSString *)key
+- (void)getBoolean:(NSString *)name
+               key:(NSString *)key
            resolve:(RCTPromiseResolveBlock)resolve
             reject:(RCTPromiseRejectBlock)reject
 {
@@ -215,10 +203,7 @@ RCT_EXPORT_MODULE(TurboPreferences)
         return;
     }
 
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-
-    id value = [defaults objectForKey:key];
+    id value = [[self defaultsForName:name] objectForKey:key];
     if ([value isKindOfClass:[NSNumber class]]) {
         resolve(@([value boolValue]));
     } else {
@@ -226,7 +211,8 @@ RCT_EXPORT_MODULE(TurboPreferences)
     }
 }
 
-- (void)setInt:(NSString *)key
+- (void)setInt:(NSString *)name
+           key:(NSString *)key
          value:(NSInteger)value
        resolve:(RCTPromiseResolveBlock)resolve
         reject:(RCTPromiseRejectBlock)reject
@@ -236,14 +222,12 @@ RCT_EXPORT_MODULE(TurboPreferences)
         return;
     }
 
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-
-    [defaults setInteger:value forKey:key];
+    [[self defaultsForName:name] setInteger:value forKey:key];
     resolve(nil);
 }
 
-- (void)getInt:(NSString *)key
+- (void)getInt:(NSString *)name
+           key:(NSString *)key
        resolve:(RCTPromiseResolveBlock)resolve
         reject:(RCTPromiseRejectBlock)reject
 {
@@ -252,10 +236,7 @@ RCT_EXPORT_MODULE(TurboPreferences)
         return;
     }
 
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-
-    id value = [defaults objectForKey:key];
+    id value = [[self defaultsForName:name] objectForKey:key];
     if ([value isKindOfClass:[NSNumber class]]) {
         resolve(@([value longLongValue]));
     } else {
@@ -263,7 +244,8 @@ RCT_EXPORT_MODULE(TurboPreferences)
     }
 }
 
-- (void)setDouble:(NSString *)key
+- (void)setDouble:(NSString *)name
+              key:(NSString *)key
             value:(double)value
           resolve:(RCTPromiseResolveBlock)resolve
            reject:(RCTPromiseRejectBlock)reject
@@ -273,14 +255,12 @@ RCT_EXPORT_MODULE(TurboPreferences)
         return;
     }
 
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-
-    [defaults setDouble:value forKey:key];
+    [[self defaultsForName:name] setDouble:value forKey:key];
     resolve(nil);
 }
 
-- (void)getDouble:(NSString *)key
+- (void)getDouble:(NSString *)name
+              key:(NSString *)key
           resolve:(RCTPromiseResolveBlock)resolve
            reject:(RCTPromiseRejectBlock)reject
 {
@@ -289,10 +269,7 @@ RCT_EXPORT_MODULE(TurboPreferences)
         return;
     }
 
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-
-    id value = [defaults objectForKey:key];
+    id value = [[self defaultsForName:name] objectForKey:key];
     if ([value isKindOfClass:[NSNumber class]]) {
         resolve(@([value doubleValue]));
     } else {
@@ -300,7 +277,10 @@ RCT_EXPORT_MODULE(TurboPreferences)
     }
 }
 
-- (void)setMultiple:(NSArray *)values
+#pragma mark - Batch ops
+
+- (void)setMultiple:(NSString *)name
+             values:(NSArray *)values
             resolve:(RCTPromiseResolveBlock)resolve
              reject:(RCTPromiseRejectBlock)reject
 {
@@ -308,15 +288,13 @@ RCT_EXPORT_MODULE(TurboPreferences)
         reject(@"INVALID_VALUES", @"Values must be an array", nil);
         return;
     }
-    
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
+
+    NSUserDefaults *defaults = [self defaultsForName:name];
     for (NSDictionary *item in values) {
         if ([item isKindOfClass:[NSDictionary class]]) {
             NSString *key = item[@"key"];
             NSString *value = item[@"value"];
-            
+
             if (key && [key isKindOfClass:[NSString class]]) {
                 if (value && [value isKindOfClass:[NSString class]]) {
                     [defaults setObject:value forKey:key];
@@ -326,16 +304,11 @@ RCT_EXPORT_MODULE(TurboPreferences)
             }
         }
     }
-    
-    BOOL success = [defaults synchronize];
-    if (success) {
-        resolve(@(YES));
-    } else {
-        reject(@"SYNC_FAILED", @"Failed to synchronize UserDefaults", nil);
-    }
+    resolve(nil);
 }
 
-- (void)getMultiple:(NSArray *)keys
+- (void)getMultiple:(NSString *)name
+               keys:(NSArray *)keys
             resolve:(RCTPromiseResolveBlock)resolve
              reject:(RCTPromiseRejectBlock)reject
 {
@@ -343,23 +316,22 @@ RCT_EXPORT_MODULE(TurboPreferences)
         reject(@"INVALID_KEYS", @"Keys must be an array", nil);
         return;
     }
-    
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
+
+    NSUserDefaults *defaults = [self defaultsForName:name];
     NSMutableDictionary *result = [NSMutableDictionary dictionary];
-    
+
     for (NSString *key in keys) {
         if ([key isKindOfClass:[NSString class]]) {
             NSString *value = [defaults stringForKey:key];
             result[key] = value ?: [NSNull null];
         }
     }
-    
+
     resolve(result);
 }
 
-- (void)clearMultiple:(NSArray *)keys
+- (void)clearMultiple:(NSString *)name
+                 keys:(NSArray *)keys
               resolve:(RCTPromiseResolveBlock)resolve
                reject:(RCTPromiseRejectBlock)reject
 {
@@ -367,67 +339,51 @@ RCT_EXPORT_MODULE(TurboPreferences)
         reject(@"INVALID_KEYS", @"Keys must be an array", nil);
         return;
     }
-    
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
+
+    NSUserDefaults *defaults = [self defaultsForName:name];
     for (NSString *key in keys) {
         if ([key isKindOfClass:[NSString class]]) {
             [defaults removeObjectForKey:key];
         }
     }
-    
-    BOOL success = [defaults synchronize];
-    if (success) {
-        resolve(@(YES));
-    } else {
-        reject(@"SYNC_FAILED", @"Failed to synchronize UserDefaults", nil);
-    }
+    resolve(nil);
 }
 
-- (void)getAll:(RCTPromiseResolveBlock)resolve
+#pragma mark - Whole-store ops
+
+- (void)getAll:(NSString *)name
+       resolve:(RCTPromiseResolveBlock)resolve
         reject:(RCTPromiseRejectBlock)reject
 {
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
-    NSDictionary *allValues = [defaults dictionaryRepresentation];
+    // The store's persistent domain only — unlike dictionaryRepresentation,
+    // this excludes NSGlobalDomain (AppleLanguages and friends)
+    [self defaultsForName:name]; // ensure the store is cached/watched
+    NSDictionary *allValues = [self snapshotForToken:[self tokenForName:name]];
     NSMutableDictionary *stringValues = [NSMutableDictionary dictionary];
-    
+
     for (NSString *key in allValues) {
         id value = allValues[key];
         if ([value isKindOfClass:[NSString class]]) {
-            // Skip our internal keys
-            if (![key hasPrefix:@"__turbo_preferences_"]) {
-                stringValues[key] = value;
-            }
+            stringValues[key] = value;
+        } else if ([value isKindOfClass:[NSNumber class]]) {
+            // Typed values come back stringified, matching Android's getAll
+            stringValues[key] = [value stringValue];
         }
     }
-    
+
     resolve(stringValues);
 }
 
-- (void)clearAll:(RCTPromiseResolveBlock)resolve
+- (void)clearAll:(NSString *)name
+         resolve:(RCTPromiseResolveBlock)resolve
           reject:(RCTPromiseRejectBlock)reject
 {
-    NSString *suiteName = [[self userDefaults] objectForKey:@"__turbo_preferences_suite_name__"];
-    NSUserDefaults *defaults = [self userDefaultsWithSuite:suiteName];
-    
-    // Get all keys and remove them (except our internal ones)
-    NSDictionary *allValues = [defaults dictionaryRepresentation];
-    for (NSString *key in allValues) {
-        if (![key hasPrefix:@"__turbo_preferences_"]) {
-            [defaults removeObjectForKey:key];
-        }
-    }
-    
-    BOOL success = [defaults synchronize];
-    if (success) {
-        resolve(@(YES));
-    } else {
-        reject(@"SYNC_FAILED", @"Failed to synchronize UserDefaults", nil);
-    }
+    NSUserDefaults *defaults = [self defaultsForName:name];
+    [defaults removePersistentDomainForName:[self domainForToken:[self tokenForName:name]]];
+    resolve(nil);
 }
+
+#pragma mark - Widgets
 
 - (void)reloadWidgets:(NSString *)kind
               resolve:(RCTPromiseResolveBlock)resolve

--- a/src/NativeTurboPreferences.ts
+++ b/src/NativeTurboPreferences.ts
@@ -11,22 +11,28 @@ export type PreferenceChangeEvent = {
    * (e.g. clearAll) — re-read anything you care about.
    */
   key?: string | null;
+  /**
+   * The store the change happened in: the suite/file name, or null for
+   * the default store.
+   */
+  store?: string | null;
 };
 
+/**
+ * Every method takes the store name as its first argument so the native
+ * layer stays stateless — pass null for the default store.
+ * iOS: UserDefaults(suiteName: name) / standardUserDefaults.
+ * Android: getSharedPreferences(name, MODE_PRIVATE) / the "default" file.
+ *
+ * JS-side store handles (createStore) and the deprecated setName shim
+ * both route through these.
+ */
 export interface Spec extends TurboModule {
-  // ----- Namespace / file selection -----
-  /**
-   * iOS: UserDefaults(suiteName)
-   * Android: getSharedPreferences(name, MODE_PRIVATE)
-   * Pass undefined/null to go back to the standard/default file.
-   */
-  setName(name: string | null): Promise<void>;
-
   // ----- Single key ops -----
-  get(key: string): Promise<string | null>;
-  set(key: string, value: string): Promise<void>;
-  clear(key: string): Promise<void>;
-  contains(key: string): Promise<boolean>; // aka hasKey
+  get(name: string | null, key: string): Promise<string | null>;
+  set(name: string | null, key: string, value: string): Promise<void>;
+  clear(name: string | null, key: string): Promise<void>;
+  contains(name: string | null, key: string): Promise<boolean>; // aka hasKey
 
   // ----- Typed ops -----
   /**
@@ -38,29 +44,36 @@ export interface Spec extends TurboModule {
    * Typed getters resolve null when the key is missing or holds an
    * incompatible type.
    */
-  setBoolean(key: string, value: boolean): Promise<void>;
-  getBoolean(key: string): Promise<boolean | null>;
-  setInt(key: string, value: Int32): Promise<void>;
-  getInt(key: string): Promise<number | null>;
-  setDouble(key: string, value: number): Promise<void>;
-  getDouble(key: string): Promise<number | null>;
+  setBoolean(name: string | null, key: string, value: boolean): Promise<void>;
+  getBoolean(name: string | null, key: string): Promise<boolean | null>;
+  setInt(name: string | null, key: string, value: Int32): Promise<void>;
+  getInt(name: string | null, key: string): Promise<number | null>;
+  setDouble(name: string | null, key: string, value: number): Promise<void>;
+  getDouble(name: string | null, key: string): Promise<number | null>;
 
   // ----- Batch ops -----
-  setMultiple(values: { key: string; value: string }[]): Promise<void>;
-  getMultiple(keys: string[]): Promise<{ [key: string]: string | null }>;
-  clearMultiple(keys: string[]): Promise<void>;
+  setMultiple(
+    name: string | null,
+    values: { key: string; value: string }[]
+  ): Promise<void>;
+  getMultiple(
+    name: string | null,
+    keys: string[]
+  ): Promise<{ [key: string]: string | null }>;
+  clearMultiple(name: string | null, keys: string[]): Promise<void>;
 
   // ----- Whole-store ops -----
-  getAll(): Promise<{ [key: string]: string }>;
-  clearAll(): Promise<void>;
+  getAll(name: string | null): Promise<{ [key: string]: string }>;
+  clearAll(name: string | null): Promise<void>;
 
   // ----- Change events -----
   /**
-   * Fires when a value in the current store changes — including writes
-   * made by native code (widgets, SDKs), not just through this module.
+   * Fires when a value changes in any store this module has touched —
+   * including writes made by native code (widgets, SDKs), not just
+   * through this module.
    * iOS: NSUserDefaultsDidChangeNotification (in-process changes) diffed
-   * against a snapshot of the store.
-   * Android: SharedPreferences.OnSharedPreferenceChangeListener.
+   * against per-store snapshots.
+   * Android: SharedPreferences.OnSharedPreferenceChangeListener per store.
    */
   readonly onPreferenceChange: EventEmitter<PreferenceChangeEvent>;
 

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -2,7 +2,6 @@
 jest.mock('../NativeTurboPreferences', () => ({
   __esModule: true,
   default: {
-    setName: jest.fn(),
     get: jest.fn(),
     getAll: jest.fn(),
     set: jest.fn(),
@@ -48,41 +47,55 @@ import {
 const mockModule = require('../NativeTurboPreferences').default;
 
 describe('React Native Turbo Preferences', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
+    await setName(null);
   });
 
-  describe('setName', () => {
-    it('should switch to user-specific namespace', async () => {
-      mockModule.setName.mockResolvedValue(undefined);
+  describe('setName (deprecated global store)', () => {
+    it('should route subsequent calls to the selected store', async () => {
+      mockModule.get.mockResolvedValue('dark');
 
       await setName('user_123_preferences');
+      await get('theme');
 
-      expect(mockModule.setName).toHaveBeenCalledWith('user_123_preferences');
+      expect(mockModule.get).toHaveBeenCalledWith(
+        'user_123_preferences',
+        'theme'
+      );
     });
 
-    it('should switch to app group namespace (iOS)', async () => {
-      mockModule.setName.mockResolvedValue(undefined);
+    it('should route to an app group namespace (iOS)', async () => {
+      mockModule.set.mockResolvedValue(undefined);
 
       await setName('group.com.myapp.shared');
+      await set('streak', '42');
 
-      expect(mockModule.setName).toHaveBeenCalledWith('group.com.myapp.shared');
+      expect(mockModule.set).toHaveBeenCalledWith(
+        'group.com.myapp.shared',
+        'streak',
+        '42'
+      );
     });
 
-    it('should reset to default namespace', async () => {
-      mockModule.setName.mockResolvedValue(undefined);
+    it('should reset to the default store with an empty string', async () => {
+      mockModule.get.mockResolvedValue(null);
 
+      await setName('some_namespace');
       await setName('');
+      await get('theme');
 
-      expect(mockModule.setName).toHaveBeenCalledWith('');
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'theme');
     });
 
-    it('should handle null namespace', async () => {
-      mockModule.setName.mockResolvedValue(undefined);
+    it('should reset to the default store with null', async () => {
+      mockModule.get.mockResolvedValue(null);
 
+      await setName('some_namespace');
       await setName(null as any);
+      await get('theme');
 
-      expect(mockModule.setName).toHaveBeenCalledWith(null);
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'theme');
     });
   });
 
@@ -93,7 +106,7 @@ describe('React Native Turbo Preferences', () => {
 
       const result = await get('theme');
 
-      expect(mockModule.get).toHaveBeenCalledWith('theme');
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'theme');
       expect(result).toBe(expectedValue);
     });
 
@@ -102,7 +115,7 @@ describe('React Native Turbo Preferences', () => {
 
       const result = await get('non_existent_key');
 
-      expect(mockModule.get).toHaveBeenCalledWith('non_existent_key');
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'non_existent_key');
       expect(result).toBe(null);
     });
 
@@ -117,7 +130,7 @@ describe('React Native Turbo Preferences', () => {
 
       const result = await get('user_profile');
 
-      expect(mockModule.get).toHaveBeenCalledWith('user_profile');
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'user_profile');
       expect(result).toBe(jsonString);
       expect(JSON.parse(result!)).toEqual(userData);
     });
@@ -127,7 +140,7 @@ describe('React Native Turbo Preferences', () => {
 
       const result = await get('empty_value_key');
 
-      expect(mockModule.get).toHaveBeenCalledWith('empty_value_key');
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'empty_value_key');
       expect(result).toBe('');
     });
   });
@@ -138,7 +151,7 @@ describe('React Native Turbo Preferences', () => {
 
       await set('language', 'en');
 
-      expect(mockModule.set).toHaveBeenCalledWith('language', 'en');
+      expect(mockModule.set).toHaveBeenCalledWith(null, 'language', 'en');
     });
 
     it('should store complex data as JSON', async () => {
@@ -153,6 +166,7 @@ describe('React Native Turbo Preferences', () => {
       await set('user_settings', JSON.stringify(userSettings));
 
       expect(mockModule.set).toHaveBeenCalledWith(
+        null,
         'user_settings',
         JSON.stringify(userSettings)
       );
@@ -163,7 +177,7 @@ describe('React Native Turbo Preferences', () => {
 
       await set('empty_key', '');
 
-      expect(mockModule.set).toHaveBeenCalledWith('empty_key', '');
+      expect(mockModule.set).toHaveBeenCalledWith(null, 'empty_key', '');
     });
 
     it('should store numeric values as strings', async () => {
@@ -172,8 +186,8 @@ describe('React Native Turbo Preferences', () => {
       await set('max_retries', '3');
       await set('timeout', '5000');
 
-      expect(mockModule.set).toHaveBeenCalledWith('max_retries', '3');
-      expect(mockModule.set).toHaveBeenCalledWith('timeout', '5000');
+      expect(mockModule.set).toHaveBeenCalledWith(null, 'max_retries', '3');
+      expect(mockModule.set).toHaveBeenCalledWith(null, 'timeout', '5000');
     });
   });
 
@@ -183,7 +197,7 @@ describe('React Native Turbo Preferences', () => {
 
       await clear('temporary_token');
 
-      expect(mockModule.clear).toHaveBeenCalledWith('temporary_token');
+      expect(mockModule.clear).toHaveBeenCalledWith(null, 'temporary_token');
     });
 
     it('should handle clearing non-existent keys gracefully', async () => {
@@ -191,7 +205,7 @@ describe('React Native Turbo Preferences', () => {
 
       await clear('non_existent_key');
 
-      expect(mockModule.clear).toHaveBeenCalledWith('non_existent_key');
+      expect(mockModule.clear).toHaveBeenCalledWith(null, 'non_existent_key');
     });
   });
 
@@ -201,7 +215,7 @@ describe('React Native Turbo Preferences', () => {
 
       const exists = await contains('user_id');
 
-      expect(mockModule.contains).toHaveBeenCalledWith('user_id');
+      expect(mockModule.contains).toHaveBeenCalledWith(null, 'user_id');
       expect(exists).toBe(true);
     });
 
@@ -210,7 +224,10 @@ describe('React Native Turbo Preferences', () => {
 
       const exists = await contains('non_existent_key');
 
-      expect(mockModule.contains).toHaveBeenCalledWith('non_existent_key');
+      expect(mockModule.contains).toHaveBeenCalledWith(
+        null,
+        'non_existent_key'
+      );
       expect(exists).toBe(false);
     });
 
@@ -219,7 +236,7 @@ describe('React Native Turbo Preferences', () => {
 
       const hasConfig = await contains('app_config');
 
-      expect(mockModule.contains).toHaveBeenCalledWith('app_config');
+      expect(mockModule.contains).toHaveBeenCalledWith(null, 'app_config');
       expect(hasConfig).toBe(true);
     });
   });
@@ -296,7 +313,7 @@ describe('React Native Turbo Preferences', () => {
 
       await setMultiple(profileData);
 
-      expect(mockModule.setMultiple).toHaveBeenCalledWith(profileData);
+      expect(mockModule.setMultiple).toHaveBeenCalledWith(null, profileData);
     });
 
     it('should store app configuration in batch', async () => {
@@ -310,7 +327,7 @@ describe('React Native Turbo Preferences', () => {
 
       await setMultiple(configData);
 
-      expect(mockModule.setMultiple).toHaveBeenCalledWith(configData);
+      expect(mockModule.setMultiple).toHaveBeenCalledWith(null, configData);
     });
 
     it('should handle empty batch gracefully', async () => {
@@ -318,7 +335,7 @@ describe('React Native Turbo Preferences', () => {
 
       await setMultiple([]);
 
-      expect(mockModule.setMultiple).toHaveBeenCalledWith([]);
+      expect(mockModule.setMultiple).toHaveBeenCalledWith(null, []);
     });
   });
 
@@ -335,7 +352,7 @@ describe('React Native Turbo Preferences', () => {
 
       const result = await getMultiple(keys);
 
-      expect(mockModule.getMultiple).toHaveBeenCalledWith(keys);
+      expect(mockModule.getMultiple).toHaveBeenCalledWith(null, keys);
       expect(result).toEqual(expectedData);
     });
 
@@ -350,7 +367,7 @@ describe('React Native Turbo Preferences', () => {
 
       const result = await getMultiple(keys);
 
-      expect(mockModule.getMultiple).toHaveBeenCalledWith(keys);
+      expect(mockModule.getMultiple).toHaveBeenCalledWith(null, keys);
       expect(result).toEqual(expectedData);
     });
 
@@ -366,7 +383,7 @@ describe('React Native Turbo Preferences', () => {
 
       const result = await getMultiple(keys);
 
-      expect(mockModule.getMultiple).toHaveBeenCalledWith(keys);
+      expect(mockModule.getMultiple).toHaveBeenCalledWith(null, keys);
       expect(result).toEqual(expectedData);
     });
   });
@@ -383,7 +400,7 @@ describe('React Native Turbo Preferences', () => {
 
       await clearMultiple(keysToClear);
 
-      expect(mockModule.clearMultiple).toHaveBeenCalledWith(keysToClear);
+      expect(mockModule.clearMultiple).toHaveBeenCalledWith(null, keysToClear);
     });
 
     it('should clear app cache data in batch', async () => {
@@ -397,7 +414,7 @@ describe('React Native Turbo Preferences', () => {
 
       await clearMultiple(cacheKeys);
 
-      expect(mockModule.clearMultiple).toHaveBeenCalledWith(cacheKeys);
+      expect(mockModule.clearMultiple).toHaveBeenCalledWith(null, cacheKeys);
     });
 
     it('should handle empty keys array gracefully', async () => {
@@ -405,16 +422,14 @@ describe('React Native Turbo Preferences', () => {
 
       await clearMultiple([]);
 
-      expect(mockModule.clearMultiple).toHaveBeenCalledWith([]);
+      expect(mockModule.clearMultiple).toHaveBeenCalledWith(null, []);
     });
   });
 
   describe('Integration Scenarios', () => {
     it('should handle complete user registration flow', async () => {
       // 1. Set user namespace
-      mockModule.setName.mockResolvedValue(undefined);
       await setName('user_456');
-      expect(mockModule.setName).toHaveBeenCalledWith('user_456');
 
       // 2. Store user profile
       const profileData = [
@@ -424,7 +439,10 @@ describe('React Native Turbo Preferences', () => {
       ];
       mockModule.setMultiple.mockResolvedValue(undefined);
       await setMultiple(profileData);
-      expect(mockModule.setMultiple).toHaveBeenCalledWith(profileData);
+      expect(mockModule.setMultiple).toHaveBeenCalledWith(
+        'user_456',
+        profileData
+      );
 
       // 3. Verify profile was stored
       const profileKeys = ['username', 'email', 'created_at'];
@@ -435,7 +453,10 @@ describe('React Native Turbo Preferences', () => {
       };
       mockModule.getMultiple.mockResolvedValue(expectedProfile);
       const storedProfile = await getMultiple(profileKeys);
-      expect(mockModule.getMultiple).toHaveBeenCalledWith(profileKeys);
+      expect(mockModule.getMultiple).toHaveBeenCalledWith(
+        'user_456',
+        profileKeys
+      );
       expect(storedProfile).toEqual(expectedProfile);
     });
 
@@ -448,18 +469,18 @@ describe('React Native Turbo Preferences', () => {
       ];
       mockModule.setMultiple.mockResolvedValue(undefined);
       await setMultiple(configData);
-      expect(mockModule.setMultiple).toHaveBeenCalledWith(configData);
+      expect(mockModule.setMultiple).toHaveBeenCalledWith(null, configData);
 
       // 2. Retrieve specific config
       mockModule.get.mockResolvedValue('v2');
       const apiVersion = await get('api_version');
-      expect(mockModule.get).toHaveBeenCalledWith('api_version');
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'api_version');
       expect(apiVersion).toBe('v2');
 
       // 3. Check if config exists
       mockModule.contains.mockResolvedValue(true);
       const hasConfig = await contains('debug_mode');
-      expect(mockModule.contains).toHaveBeenCalledWith('debug_mode');
+      expect(mockModule.contains).toHaveBeenCalledWith(null, 'debug_mode');
       expect(hasConfig).toBe(true);
     });
 
@@ -467,25 +488,26 @@ describe('React Native Turbo Preferences', () => {
       // 1. Set default namespace preferences
       mockModule.set.mockResolvedValue(undefined);
       await set('default_theme', 'light');
-      expect(mockModule.set).toHaveBeenCalledWith('default_theme', 'light');
+      expect(mockModule.set).toHaveBeenCalledWith(
+        null,
+        'default_theme',
+        'light'
+      );
 
       // 2. Switch to user namespace
-      mockModule.setName.mockResolvedValue(undefined);
       await setName('user_789');
-      expect(mockModule.setName).toHaveBeenCalledWith('user_789');
 
       // 3. Set user-specific preferences
       await set('theme', 'dark');
-      expect(mockModule.set).toHaveBeenCalledWith('theme', 'dark');
+      expect(mockModule.set).toHaveBeenCalledWith('user_789', 'theme', 'dark');
 
       // 4. Switch back to default
       await setName('');
-      expect(mockModule.setName).toHaveBeenCalledWith('');
 
       // 5. Verify default preferences still exist
       mockModule.get.mockResolvedValue('light');
       const defaultTheme = await get('default_theme');
-      expect(mockModule.get).toHaveBeenCalledWith('default_theme');
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'default_theme');
       expect(defaultTheme).toBe('light');
     });
 
@@ -498,13 +520,13 @@ describe('React Native Turbo Preferences', () => {
       ];
       mockModule.setMultiple.mockResolvedValue(undefined);
       await setMultiple(testData);
-      expect(mockModule.setMultiple).toHaveBeenCalledWith(testData);
+      expect(mockModule.setMultiple).toHaveBeenCalledWith(null, testData);
 
       // 2. Clear specific temporary files
       const tempKeys = ['temp_file_1', 'temp_file_2'];
       mockModule.clearMultiple.mockResolvedValue(undefined);
       await clearMultiple(tempKeys);
-      expect(mockModule.clearMultiple).toHaveBeenCalledWith(tempKeys);
+      expect(mockModule.clearMultiple).toHaveBeenCalledWith(null, tempKeys);
 
       // 3. Clear all remaining data
       mockModule.clearAll.mockResolvedValue(undefined);
@@ -522,6 +544,7 @@ describe('React Native Turbo Preferences', () => {
         'Storage full'
       );
       expect(mockModule.set).toHaveBeenCalledWith(
+        null,
         'large_data',
         'x'.repeat(1000000)
       );
@@ -532,7 +555,7 @@ describe('React Native Turbo Preferences', () => {
       mockModule.get.mockRejectedValue(permissionError);
 
       await expect(get('restricted_key')).rejects.toThrow('Permission denied');
-      expect(mockModule.get).toHaveBeenCalledWith('restricted_key');
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'restricted_key');
     });
 
     it('should handle network errors gracefully', async () => {
@@ -545,7 +568,7 @@ describe('React Native Turbo Preferences', () => {
       }));
 
       await expect(setMultiple(largeData)).rejects.toThrow('Network timeout');
-      expect(mockModule.setMultiple).toHaveBeenCalledWith(largeData);
+      expect(mockModule.setMultiple).toHaveBeenCalledWith(null, largeData);
     });
   });
 
@@ -562,21 +585,23 @@ describe('React Native Turbo Preferences', () => {
       const duration = performance.now() - startTime;
 
       expect(duration).toBeLessThan(1000); // Should complete in under 1 second
-      expect(mockModule.setMultiple).toHaveBeenCalledWith(largeDataset);
+      expect(mockModule.setMultiple).toHaveBeenCalledWith(null, largeDataset);
     });
 
     it('should handle rapid namespace switching', async () => {
       const namespaces = Array.from({ length: 100 }, (_, i) => `ns_${i}`);
-      mockModule.setName.mockResolvedValue(undefined);
+      mockModule.get.mockResolvedValue(null);
 
       const startTime = performance.now();
       for (const ns of namespaces) {
         await setName(ns);
+        await get('key');
       }
       const duration = performance.now() - startTime;
 
       expect(duration).toBeLessThan(5000); // Should complete in under 5 seconds
-      expect(mockModule.setName).toHaveBeenCalledTimes(100);
+      expect(mockModule.get).toHaveBeenCalledTimes(100);
+      expect(mockModule.get).toHaveBeenLastCalledWith('ns_99', 'key');
     });
   });
 
@@ -588,7 +613,11 @@ describe('React Native Turbo Preferences', () => {
       await setBoolean('darkMode', true);
       const value = await getBoolean('darkMode');
 
-      expect(mockModule.setBoolean).toHaveBeenCalledWith('darkMode', true);
+      expect(mockModule.setBoolean).toHaveBeenCalledWith(
+        null,
+        'darkMode',
+        true
+      );
       expect(value).toBe(true);
     });
 
@@ -599,7 +628,7 @@ describe('React Native Turbo Preferences', () => {
       await setInt('streak', 42);
       const value = await getInt('streak');
 
-      expect(mockModule.setInt).toHaveBeenCalledWith('streak', 42);
+      expect(mockModule.setInt).toHaveBeenCalledWith(null, 'streak', 42);
       expect(value).toBe(42);
     });
 
@@ -626,8 +655,8 @@ describe('React Native Turbo Preferences', () => {
       await setInt('max', 2147483647);
       await setInt('min', -2147483648);
 
-      expect(mockModule.setInt).toHaveBeenCalledWith('max', 2147483647);
-      expect(mockModule.setInt).toHaveBeenCalledWith('min', -2147483648);
+      expect(mockModule.setInt).toHaveBeenCalledWith(null, 'max', 2147483647);
+      expect(mockModule.setInt).toHaveBeenCalledWith(null, 'min', -2147483648);
     });
 
     it('should set and get a double', async () => {
@@ -637,7 +666,7 @@ describe('React Native Turbo Preferences', () => {
       await setDouble('ratio', 3.14);
       const value = await getDouble('ratio');
 
-      expect(mockModule.setDouble).toHaveBeenCalledWith('ratio', 3.14);
+      expect(mockModule.setDouble).toHaveBeenCalledWith(null, 'ratio', 3.14);
       expect(value).toBe(3.14);
     });
 
@@ -676,6 +705,96 @@ describe('React Native Turbo Preferences', () => {
       captured?.({ key: 'theme' });
 
       expect(listener).toHaveBeenCalledWith({ key: 'theme' });
+    });
+  });
+
+  describe('createStore', () => {
+    const { createStore } = require('../index');
+
+    it('should route calls to the named store', async () => {
+      mockModule.set.mockResolvedValue(undefined);
+      mockModule.getInt.mockResolvedValue(42);
+
+      const appGroup = createStore('group.com.myapp.shared');
+      await appGroup.set('lastWorkout', 'Push day');
+      const streak = await appGroup.getInt('streak');
+
+      expect(appGroup.name).toBe('group.com.myapp.shared');
+      expect(mockModule.set).toHaveBeenCalledWith(
+        'group.com.myapp.shared',
+        'lastWorkout',
+        'Push day'
+      );
+      expect(mockModule.getInt).toHaveBeenCalledWith(
+        'group.com.myapp.shared',
+        'streak'
+      );
+      expect(streak).toBe(42);
+    });
+
+    it('should route to the default store when created without a name', async () => {
+      mockModule.get.mockResolvedValue('dark');
+
+      const defaults = createStore();
+      await defaults.get('theme');
+
+      expect(defaults.name).toBeNull();
+      expect(mockModule.get).toHaveBeenCalledWith(null, 'theme');
+    });
+
+    it('should allow two stores side by side without global state', async () => {
+      mockModule.set.mockResolvedValue(undefined);
+
+      const a = createStore('store_a');
+      const b = createStore('store_b');
+      await a.set('k', '1');
+      await b.set('k', '2');
+      await a.set('k2', '3');
+
+      expect(mockModule.set).toHaveBeenNthCalledWith(1, 'store_a', 'k', '1');
+      expect(mockModule.set).toHaveBeenNthCalledWith(2, 'store_b', 'k', '2');
+      expect(mockModule.set).toHaveBeenNthCalledWith(3, 'store_a', 'k2', '3');
+    });
+
+    it('should validate setInt on store handles', async () => {
+      const store = createStore('store_a');
+
+      await expect(store.setInt('n', 1.5)).rejects.toThrow(
+        /expects a 32-bit integer/
+      );
+      expect(mockModule.setInt).not.toHaveBeenCalled();
+    });
+
+    it('should filter store.addListener events to its own store', () => {
+      let captured: ((event: any) => void) | undefined;
+      mockModule.onPreferenceChange.mockImplementation((cb: any) => {
+        captured = cb;
+        return { remove: jest.fn() };
+      });
+      const listener = jest.fn();
+
+      const store = createStore('store_a');
+      store.addListener(listener);
+
+      captured?.({ key: 'k', store: 'store_b' });
+      expect(listener).not.toHaveBeenCalled();
+
+      captured?.({ key: 'k', store: 'store_a' });
+      expect(listener).toHaveBeenCalledWith({ key: 'k', store: 'store_a' });
+    });
+
+    it('should match null-store events for the default store handle', () => {
+      let captured: ((event: any) => void) | undefined;
+      mockModule.onPreferenceChange.mockImplementation((cb: any) => {
+        captured = cb;
+        return { remove: jest.fn() };
+      });
+      const listener = jest.fn();
+
+      createStore().addListener(listener);
+      captured?.({ key: 'k', store: null });
+
+      expect(listener).toHaveBeenCalledWith({ key: 'k', store: null });
     });
   });
 

--- a/src/currentStore.ts
+++ b/src/currentStore.ts
@@ -1,0 +1,12 @@
+// Module-level state backing the deprecated global-namespace API
+// (setName + top-level get/set/...). New code should use createStore().
+
+let currentName: string | null = null;
+
+export function getCurrentName(): string | null {
+  return currentName;
+}
+
+export function setCurrentName(name: string | null): void {
+  currentName = name && name.length > 0 ? name : null;
+}

--- a/src/hooks/__tests__/usePreferenceString.test.tsx
+++ b/src/hooks/__tests__/usePreferenceString.test.tsx
@@ -27,9 +27,10 @@ describe('usePreferenceString', () => {
   it('should call TurboPreferences.set when setting a value', async () => {
     mockTurboPreferences.set.mockResolvedValue(undefined);
 
-    await mockTurboPreferences.set('test_key', 'test_value');
+    await mockTurboPreferences.set(null, 'test_key', 'test_value');
 
     expect(mockTurboPreferences.set).toHaveBeenCalledWith(
+      null,
       'test_key',
       'test_value'
     );
@@ -38,26 +39,29 @@ describe('usePreferenceString', () => {
   it('should call TurboPreferences.get when getting a value', async () => {
     mockTurboPreferences.get.mockResolvedValue('test_value');
 
-    const result = await mockTurboPreferences.get('test_key');
+    const result = await mockTurboPreferences.get(null, 'test_key');
 
-    expect(mockTurboPreferences.get).toHaveBeenCalledWith('test_key');
+    expect(mockTurboPreferences.get).toHaveBeenCalledWith(null, 'test_key');
     expect(result).toBe('test_value');
   });
 
   it('should call TurboPreferences.clear when clearing a value', async () => {
     mockTurboPreferences.clear.mockResolvedValue(undefined);
 
-    await mockTurboPreferences.clear('test_key');
+    await mockTurboPreferences.clear(null, 'test_key');
 
-    expect(mockTurboPreferences.clear).toHaveBeenCalledWith('test_key');
+    expect(mockTurboPreferences.clear).toHaveBeenCalledWith(null, 'test_key');
   });
 
   it('should call TurboPreferences.contains when checking if key exists', async () => {
     mockTurboPreferences.contains.mockResolvedValue(true);
 
-    const result = await mockTurboPreferences.contains('test_key');
+    const result = await mockTurboPreferences.contains(null, 'test_key');
 
-    expect(mockTurboPreferences.contains).toHaveBeenCalledWith('test_key');
+    expect(mockTurboPreferences.contains).toHaveBeenCalledWith(
+      null,
+      'test_key'
+    );
     expect(result).toBe(true);
   });
 });

--- a/src/hooks/usePreferenceBoolean.ts
+++ b/src/hooks/usePreferenceBoolean.ts
@@ -1,10 +1,14 @@
 import { useState, useCallback, useEffect } from 'react';
 import TurboPreferences from '../NativeTurboPreferences';
+import { getCurrentName } from '../currentStore';
+import type { PreferenceStore } from '../store';
 
 /**
  * React hook for managing a boolean preference
  *
  * @param key - The preference key
+ * @param store - Optional store handle from createStore(); defaults to
+ * the store selected by the global API
  * @returns [value, setValue, contains, clear]
  *
  * @example
@@ -23,7 +27,8 @@ import TurboPreferences from '../NativeTurboPreferences';
  * ```
  */
 export function usePreferenceBoolean(
-  key: string
+  key: string,
+  store?: PreferenceStore
 ): [
   boolean | null,
   (value: boolean) => Promise<void>,
@@ -32,14 +37,16 @@ export function usePreferenceBoolean(
 ] {
   const [value, setValue] = useState<boolean | null>(null);
   const [contains, setContains] = useState<boolean>(false);
+  const storeName = store ? store.name : undefined;
 
   const setPreferenceValue = useCallback(
     async (newValue: boolean) => {
       if (!key) return;
 
       try {
+        const name = storeName !== undefined ? storeName : getCurrentName();
         // Convert boolean to string for storage
-        await TurboPreferences.set(key, String(newValue));
+        await TurboPreferences.set(name, key, String(newValue));
         setValue(newValue);
         setContains(true);
       } catch (error) {
@@ -47,21 +54,22 @@ export function usePreferenceBoolean(
         throw error;
       }
     },
-    [key]
+    [key, storeName]
   );
 
   const clearPreferenceValue = useCallback(async () => {
     if (!key) return;
 
     try {
-      await TurboPreferences.clear(key);
+      const name = storeName !== undefined ? storeName : getCurrentName();
+      await TurboPreferences.clear(name, key);
       setValue(null);
       setContains(false);
     } catch (error) {
       console.warn('usePreferenceBoolean clear error:', error);
       throw error;
     }
-  }, [key]);
+  }, [key, storeName]);
 
   // Load on mount/key change, and reload when the store changes —
   // including writes from other components or native code
@@ -69,11 +77,15 @@ export function usePreferenceBoolean(
     if (!key) return;
     let active = true;
 
+    const resolveName = () =>
+      storeName !== undefined ? storeName : getCurrentName();
+
     const load = async () => {
       try {
+        const name = resolveName();
         const [currentValue, exists] = await Promise.all([
-          TurboPreferences.get(key),
-          TurboPreferences.contains(key),
+          TurboPreferences.get(name, key),
+          TurboPreferences.contains(name, key),
         ]);
         if (!active) return;
 
@@ -98,6 +110,7 @@ export function usePreferenceBoolean(
 
     load();
     const subscription = TurboPreferences.onPreferenceChange((event) => {
+      if ((event.store ?? null) !== resolveName()) return;
       if (event.key == null || event.key === key) load();
     });
 
@@ -105,7 +118,7 @@ export function usePreferenceBoolean(
       active = false;
       subscription.remove();
     };
-  }, [key]);
+  }, [key, storeName]);
 
   return [value, setPreferenceValue, contains, clearPreferenceValue];
 }

--- a/src/hooks/usePreferenceNamespace.ts
+++ b/src/hooks/usePreferenceNamespace.ts
@@ -1,8 +1,12 @@
 import { useState, useCallback } from 'react';
-import TurboPreferences from '../NativeTurboPreferences';
+import { getCurrentName, setCurrentName } from '../currentStore';
 
 /**
- * React hook for managing preference namespaces
+ * React hook for managing the global preference namespace.
+ *
+ * @deprecated Prefer `createStore(name)` — hold one handle per store
+ * instead of switching a global. This hook drives the same global
+ * "current store" as the deprecated `setName()`.
  *
  * @returns [currentNamespace, setNamespace, resetToDefault]
  *
@@ -28,27 +32,18 @@ export function usePreferenceNamespace(): [
   (namespace: string) => Promise<void>,
   () => Promise<void>,
 ] {
-  const [currentNamespace, setCurrentNamespace] = useState<string>('');
+  const [currentNamespace, setCurrentNamespace] = useState<string>(
+    () => getCurrentName() ?? ''
+  );
 
   const setNamespace = useCallback(async (namespace: string) => {
-    try {
-      await TurboPreferences.setName(namespace);
-      setCurrentNamespace(namespace);
-    } catch (error) {
-      console.warn('usePreferenceNamespace setNamespace error:', error);
-      throw error;
-    }
+    setCurrentName(namespace);
+    setCurrentNamespace(namespace);
   }, []);
 
   const resetToDefault = useCallback(async () => {
-    try {
-      // Pass null to go back to default namespace
-      await TurboPreferences.setName(null);
-      setCurrentNamespace('');
-    } catch (error) {
-      console.warn('usePreferenceNamespace resetToDefault error:', error);
-      throw error;
-    }
+    setCurrentName(null);
+    setCurrentNamespace('');
   }, []);
 
   return [currentNamespace, setNamespace, resetToDefault];

--- a/src/hooks/usePreferenceNumber.ts
+++ b/src/hooks/usePreferenceNumber.ts
@@ -1,10 +1,14 @@
 import { useState, useCallback, useEffect } from 'react';
 import TurboPreferences from '../NativeTurboPreferences';
+import { getCurrentName } from '../currentStore';
+import type { PreferenceStore } from '../store';
 
 /**
  * React hook for managing a number preference
  *
  * @param key - The preference key
+ * @param store - Optional store handle from createStore(); defaults to
+ * the store selected by the global API
  * @returns [value, setValue, contains, clear]
  *
  * @example
@@ -23,7 +27,8 @@ import TurboPreferences from '../NativeTurboPreferences';
  * ```
  */
 export function usePreferenceNumber(
-  key: string
+  key: string,
+  store?: PreferenceStore
 ): [
   number | null,
   (value: number) => Promise<void>,
@@ -32,14 +37,16 @@ export function usePreferenceNumber(
 ] {
   const [value, setValue] = useState<number | null>(null);
   const [contains, setContains] = useState<boolean>(false);
+  const storeName = store ? store.name : undefined;
 
   const setPreferenceValue = useCallback(
     async (newValue: number) => {
       if (!key) return;
 
       try {
+        const name = storeName !== undefined ? storeName : getCurrentName();
         // Convert number to string for storage
-        await TurboPreferences.set(key, String(newValue));
+        await TurboPreferences.set(name, key, String(newValue));
         setValue(newValue);
         setContains(true);
       } catch (error) {
@@ -47,21 +54,22 @@ export function usePreferenceNumber(
         throw error;
       }
     },
-    [key]
+    [key, storeName]
   );
 
   const clearPreferenceValue = useCallback(async () => {
     if (!key) return;
 
     try {
-      await TurboPreferences.clear(key);
+      const name = storeName !== undefined ? storeName : getCurrentName();
+      await TurboPreferences.clear(name, key);
       setValue(null);
       setContains(false);
     } catch (error) {
       console.warn('usePreferenceNumber clear error:', error);
       throw error;
     }
-  }, [key]);
+  }, [key, storeName]);
 
   // Load on mount/key change, and reload when the store changes —
   // including writes from other components or native code
@@ -69,11 +77,15 @@ export function usePreferenceNumber(
     if (!key) return;
     let active = true;
 
+    const resolveName = () =>
+      storeName !== undefined ? storeName : getCurrentName();
+
     const load = async () => {
       try {
+        const name = resolveName();
         const [currentValue, exists] = await Promise.all([
-          TurboPreferences.get(key),
-          TurboPreferences.contains(key),
+          TurboPreferences.get(name, key),
+          TurboPreferences.contains(name, key),
         ]);
         if (!active) return;
 
@@ -92,6 +104,7 @@ export function usePreferenceNumber(
 
     load();
     const subscription = TurboPreferences.onPreferenceChange((event) => {
+      if ((event.store ?? null) !== resolveName()) return;
       if (event.key == null || event.key === key) load();
     });
 
@@ -99,7 +112,7 @@ export function usePreferenceNumber(
       active = false;
       subscription.remove();
     };
-  }, [key]);
+  }, [key, storeName]);
 
   return [value, setPreferenceValue, contains, clearPreferenceValue];
 }

--- a/src/hooks/usePreferenceObject.ts
+++ b/src/hooks/usePreferenceObject.ts
@@ -1,10 +1,14 @@
 import { useState, useCallback, useEffect } from 'react';
 import TurboPreferences from '../NativeTurboPreferences';
+import { getCurrentName } from '../currentStore';
+import type { PreferenceStore } from '../store';
 
 /**
  * React hook for managing an object preference with JSON serialization
  *
  * @param key - The preference key
+ * @param store - Optional store handle from createStore(); defaults to
+ * the store selected by the global API
  * @returns [value, setValue, contains, clear]
  *
  * @example
@@ -32,19 +36,22 @@ import TurboPreferences from '../NativeTurboPreferences';
  * ```
  */
 export function usePreferenceObject<T>(
-  key: string
+  key: string,
+  store?: PreferenceStore
 ): [T | null, (value: T) => Promise<void>, boolean, () => Promise<void>] {
   const [value, setValue] = useState<T | null>(null);
   const [contains, setContains] = useState<boolean>(false);
+  const storeName = store ? store.name : undefined;
 
   const setPreferenceValue = useCallback(
     async (newValue: T) => {
       if (!key) return;
 
       try {
+        const name = storeName !== undefined ? storeName : getCurrentName();
         // Convert object to JSON string for storage
         const jsonString = JSON.stringify(newValue);
-        await TurboPreferences.set(key, jsonString);
+        await TurboPreferences.set(name, key, jsonString);
         setValue(newValue);
         setContains(true);
       } catch (error) {
@@ -52,21 +59,22 @@ export function usePreferenceObject<T>(
         throw error;
       }
     },
-    [key]
+    [key, storeName]
   );
 
   const clearPreferenceValue = useCallback(async () => {
     if (!key) return;
 
     try {
-      await TurboPreferences.clear(key);
+      const name = storeName !== undefined ? storeName : getCurrentName();
+      await TurboPreferences.clear(name, key);
       setValue(null);
       setContains(false);
     } catch (error) {
       console.warn('usePreferenceObject clear error:', error);
       throw error;
     }
-  }, [key]);
+  }, [key, storeName]);
 
   // Load on mount/key change, and reload when the store changes —
   // including writes from other components or native code
@@ -74,11 +82,15 @@ export function usePreferenceObject<T>(
     if (!key) return;
     let active = true;
 
+    const resolveName = () =>
+      storeName !== undefined ? storeName : getCurrentName();
+
     const load = async () => {
       try {
+        const name = resolveName();
         const [currentValue, exists] = await Promise.all([
-          TurboPreferences.get(key),
-          TurboPreferences.contains(key),
+          TurboPreferences.get(name, key),
+          TurboPreferences.contains(name, key),
         ]);
         if (!active) return;
 
@@ -102,6 +114,7 @@ export function usePreferenceObject<T>(
 
     load();
     const subscription = TurboPreferences.onPreferenceChange((event) => {
+      if ((event.store ?? null) !== resolveName()) return;
       if (event.key == null || event.key === key) load();
     });
 
@@ -109,7 +122,7 @@ export function usePreferenceObject<T>(
       active = false;
       subscription.remove();
     };
-  }, [key]);
+  }, [key, storeName]);
 
   return [value, setPreferenceValue, contains, clearPreferenceValue];
 }

--- a/src/hooks/usePreferenceString.ts
+++ b/src/hooks/usePreferenceString.ts
@@ -1,10 +1,14 @@
 import { useState, useCallback, useEffect } from 'react';
 import TurboPreferences from '../NativeTurboPreferences';
+import { getCurrentName } from '../currentStore';
+import type { PreferenceStore } from '../store';
 
 /**
  * Simple React hook for managing a string preference
  *
  * @param key - The preference key
+ * @param store - Optional store handle from createStore(); defaults to
+ * the store selected by the global API
  * @returns [value, setValue, contains, clear]
  *
  * @example
@@ -23,7 +27,8 @@ import TurboPreferences from '../NativeTurboPreferences';
  * ```
  */
 export function usePreferenceString(
-  key: string
+  key: string,
+  store?: PreferenceStore
 ): [
   string | null,
   (value: string) => Promise<void>,
@@ -32,13 +37,15 @@ export function usePreferenceString(
 ] {
   const [value, setValue] = useState<string | null>(null);
   const [contains, setContains] = useState<boolean>(false);
+  const storeName = store ? store.name : undefined;
 
   const setPreferenceValue = useCallback(
     async (newValue: string) => {
       if (!key) return;
 
       try {
-        await TurboPreferences.set(key, newValue);
+        const name = storeName !== undefined ? storeName : getCurrentName();
+        await TurboPreferences.set(name, key, newValue);
         setValue(newValue);
         setContains(true);
       } catch (error) {
@@ -46,21 +53,22 @@ export function usePreferenceString(
         throw error;
       }
     },
-    [key]
+    [key, storeName]
   );
 
   const clearPreferenceValue = useCallback(async () => {
     if (!key) return;
 
     try {
-      await TurboPreferences.clear(key);
+      const name = storeName !== undefined ? storeName : getCurrentName();
+      await TurboPreferences.clear(name, key);
       setValue(null);
       setContains(false);
     } catch (error) {
       console.warn('usePreferenceString clear error:', error);
       throw error;
     }
-  }, [key]);
+  }, [key, storeName]);
 
   // Load on mount/key change, and reload when the store changes —
   // including writes from other components or native code
@@ -68,11 +76,15 @@ export function usePreferenceString(
     if (!key) return;
     let active = true;
 
+    const resolveName = () =>
+      storeName !== undefined ? storeName : getCurrentName();
+
     const load = async () => {
       try {
+        const name = resolveName();
         const [currentValue, exists] = await Promise.all([
-          TurboPreferences.get(key),
-          TurboPreferences.contains(key),
+          TurboPreferences.get(name, key),
+          TurboPreferences.contains(name, key),
         ]);
         if (!active) return;
         setValue(currentValue);
@@ -84,6 +96,7 @@ export function usePreferenceString(
 
     load();
     const subscription = TurboPreferences.onPreferenceChange((event) => {
+      if ((event.store ?? null) !== resolveName()) return;
       if (event.key == null || event.key === key) load();
     });
 
@@ -91,7 +104,7 @@ export function usePreferenceString(
       active = false;
       subscription.remove();
     };
-  }, [key]);
+  }, [key, storeName]);
 
   return [value, setPreferenceValue, contains, clearPreferenceValue];
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,13 +1,18 @@
 import type { EventSubscription } from 'react-native';
 import TurboPreferences from './NativeTurboPreferences';
 import type { PreferenceChangeEvent } from './NativeTurboPreferences';
+import { getCurrentName, setCurrentName } from './currentStore';
+import { createStore, validateInt } from './store';
+import type { PreferenceStore } from './store';
 
-export type { PreferenceChangeEvent };
+export type { PreferenceChangeEvent, PreferenceStore };
+export { createStore };
 
 /**
- * Subscribe to changes in the current store — fires for writes made
- * through this module and by native code (widgets, SDKs).
- * `event.key` is null when the whole store changed at once.
+ * Subscribe to changes across all stores this module has touched —
+ * fires for writes made through this module and by native code
+ * (widgets, SDKs). `event.store` says which store changed; use
+ * `store.addListener()` for a single store.
  */
 export function addPreferenceChangeListener(
   listener: (event: PreferenceChangeEvent) => void
@@ -15,86 +20,123 @@ export function addPreferenceChangeListener(
   return TurboPreferences.onPreferenceChange(listener);
 }
 
+export function reloadWidgets(kind?: string): Promise<void> {
+  return TurboPreferences.reloadWidgets(kind ?? null);
+}
+
+// ---------------------------------------------------------------------------
+// Global-namespace API. These route through a module-level "current store"
+// selected with setName; prefer createStore() and one handle per store.
+// ---------------------------------------------------------------------------
+
+/** The store name the global API currently points at (null = default). */
+export function getCurrentStoreName(): string | null {
+  return getCurrentName();
+}
+
+/**
+ * @deprecated Use `createStore(name)` and keep a handle instead —
+ * setName switches a global that every call in your app shares.
+ * Note: the selection lives in JS and resets on app restart (this was
+ * already Android's behavior; iOS used to persist it across launches).
+ */
 export function setName(name: string | null): Promise<void> {
-  return TurboPreferences.setName(name);
+  setCurrentName(name);
+  return Promise.resolve();
 }
 
 export function get(key: string): Promise<string | null> {
-  return TurboPreferences.get(key);
+  return TurboPreferences.get(getCurrentName(), key);
 }
 
 export function getAll(): Promise<{ [key: string]: string } | null> {
-  return TurboPreferences.getAll();
+  return TurboPreferences.getAll(getCurrentName());
 }
 
 export function set(key: string, value: string): Promise<void> {
-  return TurboPreferences.set(key, value);
+  return TurboPreferences.set(getCurrentName(), key, value);
 }
 
 export function clear(key: string): Promise<void> {
-  return TurboPreferences.clear(key);
+  return TurboPreferences.clear(getCurrentName(), key);
 }
 
 export function clearAll(): Promise<void> {
-  return TurboPreferences.clearAll();
+  return TurboPreferences.clearAll(getCurrentName());
 }
 
 export function setMultiple(
   values: { key: string; value: string }[]
 ): Promise<void> {
-  return TurboPreferences.setMultiple(values);
+  return TurboPreferences.setMultiple(getCurrentName(), values);
 }
 
 export function getMultiple(
   keys: string[]
 ): Promise<{ [key: string]: string | null }> {
-  return TurboPreferences.getMultiple(keys);
+  return TurboPreferences.getMultiple(getCurrentName(), keys);
 }
 
 export function clearMultiple(keys: string[]): Promise<void> {
-  return TurboPreferences.clearMultiple(keys);
+  return TurboPreferences.clearMultiple(getCurrentName(), keys);
 }
 
 export function contains(key: string): Promise<boolean> {
-  return TurboPreferences.contains(key);
-}
-
-export function reloadWidgets(kind?: string): Promise<void> {
-  return TurboPreferences.reloadWidgets(kind ?? null);
+  return TurboPreferences.contains(getCurrentName(), key);
 }
 
 export function setBoolean(key: string, value: boolean): Promise<void> {
-  return TurboPreferences.setBoolean(key, value);
+  return TurboPreferences.setBoolean(getCurrentName(), key, value);
 }
 
 export function getBoolean(key: string): Promise<boolean | null> {
-  return TurboPreferences.getBoolean(key);
+  return TurboPreferences.getBoolean(getCurrentName(), key);
 }
 
 export function setInt(key: string, value: number): Promise<void> {
-  if (!Number.isInteger(value) || value < -2147483648 || value > 2147483647) {
-    return Promise.reject(
-      new TypeError(
-        `setInt expects a 32-bit integer, got ${value}. Use setDouble for other numbers.`
-      )
-    );
-  }
-  return TurboPreferences.setInt(key, value);
+  return (
+    validateInt(value) ?? TurboPreferences.setInt(getCurrentName(), key, value)
+  );
 }
 
 export function getInt(key: string): Promise<number | null> {
-  return TurboPreferences.getInt(key);
+  return TurboPreferences.getInt(getCurrentName(), key);
 }
 
 export function setDouble(key: string, value: number): Promise<void> {
-  return TurboPreferences.setDouble(key, value);
+  return TurboPreferences.setDouble(getCurrentName(), key, value);
 }
 
 export function getDouble(key: string): Promise<number | null> {
-  return TurboPreferences.getDouble(key);
+  return TurboPreferences.getDouble(getCurrentName(), key);
 }
 
 // Export hooks
 export * from './hooks';
 
-export default TurboPreferences;
+/**
+ * Default export mirrors the named functions (NOT the raw native
+ * module — its methods take a store name as the first argument).
+ */
+export default {
+  createStore,
+  addPreferenceChangeListener,
+  reloadWidgets,
+  getCurrentStoreName,
+  setName,
+  get,
+  getAll,
+  set,
+  clear,
+  clearAll,
+  setMultiple,
+  getMultiple,
+  clearMultiple,
+  contains,
+  setBoolean,
+  getBoolean,
+  setInt,
+  getInt,
+  setDouble,
+  getDouble,
+};

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,104 @@
+import type { EventSubscription } from 'react-native';
+import TurboPreferences from './NativeTurboPreferences';
+import type { PreferenceChangeEvent } from './NativeTurboPreferences';
+
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
+
+export function validateInt(value: number): Promise<void> | null {
+  if (!Number.isInteger(value) || value < INT32_MIN || value > INT32_MAX) {
+    return Promise.reject(
+      new TypeError(
+        `setInt expects a 32-bit integer, got ${value}. Use setDouble for other numbers.`
+      )
+    );
+  }
+  return null;
+}
+
+/**
+ * A handle to one preference store — the default store, a named file,
+ * or an iOS App Group container. Multiple stores can be used at the
+ * same time; handles are cheap JS objects and can be created freely.
+ */
+export interface PreferenceStore {
+  /** The suite/file name, or null for the default store. */
+  readonly name: string | null;
+
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+  clear(key: string): Promise<void>;
+  contains(key: string): Promise<boolean>;
+
+  setBoolean(key: string, value: boolean): Promise<void>;
+  getBoolean(key: string): Promise<boolean | null>;
+  setInt(key: string, value: number): Promise<void>;
+  getInt(key: string): Promise<number | null>;
+  setDouble(key: string, value: number): Promise<void>;
+  getDouble(key: string): Promise<number | null>;
+
+  setMultiple(values: { key: string; value: string }[]): Promise<void>;
+  getMultiple(keys: string[]): Promise<{ [key: string]: string | null }>;
+  clearMultiple(keys: string[]): Promise<void>;
+
+  getAll(): Promise<{ [key: string]: string }>;
+  clearAll(): Promise<void>;
+
+  /** Fires only for changes in this store. */
+  addListener(
+    listener: (event: PreferenceChangeEvent) => void
+  ): EventSubscription;
+}
+
+/**
+ * Create a handle to a preference store.
+ *
+ * @param name - iOS: UserDefaults suite (e.g. an App Group like
+ * `group.com.yourcompany.yourapp`). Android: SharedPreferences file
+ * name. Omit for the default store.
+ *
+ * @example
+ * ```ts
+ * const appGroup = createStore('group.com.yourcompany.yourapp');
+ * await appGroup.setInt('streak', 42);
+ *
+ * const defaults = createStore();
+ * await defaults.set('theme', 'dark');
+ * ```
+ */
+export function createStore(name?: string | null): PreferenceStore {
+  const storeName = name && name.length > 0 ? name : null;
+
+  return {
+    name: storeName,
+
+    get: (key) => TurboPreferences.get(storeName, key),
+    set: (key, value) => TurboPreferences.set(storeName, key, value),
+    clear: (key) => TurboPreferences.clear(storeName, key),
+    contains: (key) => TurboPreferences.contains(storeName, key),
+
+    setBoolean: (key, value) =>
+      TurboPreferences.setBoolean(storeName, key, value),
+    getBoolean: (key) => TurboPreferences.getBoolean(storeName, key),
+    setInt: (key, value) =>
+      validateInt(value) ?? TurboPreferences.setInt(storeName, key, value),
+    getInt: (key) => TurboPreferences.getInt(storeName, key),
+    setDouble: (key, value) =>
+      TurboPreferences.setDouble(storeName, key, value),
+    getDouble: (key) => TurboPreferences.getDouble(storeName, key),
+
+    setMultiple: (values) => TurboPreferences.setMultiple(storeName, values),
+    getMultiple: (keys) => TurboPreferences.getMultiple(storeName, keys),
+    clearMultiple: (keys) => TurboPreferences.clearMultiple(storeName, keys),
+
+    getAll: () => TurboPreferences.getAll(storeName),
+    clearAll: () => TurboPreferences.clearAll(storeName),
+
+    addListener: (listener) =>
+      TurboPreferences.onPreferenceChange((event) => {
+        if ((event.store ?? null) === storeName) {
+          listener(event);
+        }
+      }),
+  };
+}


### PR DESCRIPTION
## Why

The last roadmap item from #2, and the root architectural fix. `setName` was process-global mutable state: switching to a user namespace in one feature silently redirected every other feature's writes. It also behaved differently per platform (iOS persisted the selection across launches via a marker key in standard defaults; Android reset it). The widget use case makes this untenable — app + App Group stores are used *simultaneously*.

## What

### `createStore()` — handles, not global state

```typescript
const defaults = createStore();
const appGroup = createStore('group.com.yourcompany.yourapp');

await defaults.set('lastScreen', 'home');
await appGroup.setInt('streak', 42);        // both live at once
appGroup.addListener((e) => { ... });        // store-scoped change events
```

TurboModules can't return object handles, so the handle lives in JS and **every native method takes the store name as its first argument** — the native layer is now fully stateless.

### Backward compatibility
- `setName` + all top-level functions still work, as a deprecated JS shim over a module-level current store (no native call). Its selection now resets on restart — always Android's behavior; iOS's persistence was the divergence.
- Hooks unchanged by default; they accept an optional store handle as a second argument: `usePreferenceNumber('streak', appGroup)`.
- The default export is now a wrapper object mirroring the named functions (previously the raw native module — that would have silently broken with the new signatures).

### iOS cleanups that fall out of statelessness
- `__turbo_preferences_suite_name__` marker key **gone** (no more per-call lookup, no special-casing in getAll/clearAll)
- NSUserDefaults instances **cached per name** (previously allocated fresh on every call)
- `getAll` reads the store's **persistent domain** — fixes the long-standing bug where `dictionaryRepresentation` leaked NSGlobalDomain keys (`AppleLanguages` etc.) into results
- `clearAll` uses `removePersistentDomainForName:`
- deprecated `synchronize` calls removed (could reject promises for writes that actually succeeded)

### Change events
`event.store` added (null = default store). iOS keeps per-store snapshots for every touched store; Android registers one strongly-held listener per touched file, all detached on invalidate.

## Verification
- 79 tests passing (6 new createStore tests incl. side-by-side stores and store-scoped listener filtering), typecheck + lint clean
- Codegen signatures matched on both platforms
- Native compile validated by CI (real builds — cache-key fix from #8 is in)

## Release note
This is the natural **v2.0.0**: native spec changed and `setName` semantics are now uniform across platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)